### PR TITLE
restdoc output이 빌드시 포함되지 않는 이슈 해결

### DIFF
--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -51,8 +51,7 @@ tasks.named('asciidoctor') {
 
 tasks.named('bootJar') {
     dependsOn asciidoctor
-    copy {
-        from asciidoctor.outputDir
-        into "src/main/resources/static/docs"
+    from("${asciidoctor.outputDir}") {
+        into "static/docs"
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- bootJar 태스크를 수정하여 restdoc이 오픈되도록 함

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
