### PR TITLE
[Feat#42-UPDATE_QNA_ANSWER]QnA에 대한 답변을 수정하는 기능

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -245,7 +245,7 @@ include::{snippets}/post-controller-test/success_delete-post/http-response.adoc[
 .response field
 include::{snippets}/post-controller-test/success_delete-post/response-body.adoc[]
 
-=== 6. QNA 답글 생성
+=== 6. QNA 답변 작성
 .request
 include::{snippets}/qna-answer-controller-test/success_create-qna-answer/http-request.adoc[]
 
@@ -254,6 +254,17 @@ include::{snippets}/qna-answer-controller-test/success_create-qna-answer/http-re
 
 .response field
 include::{snippets}/qna-answer-controller-test/success_create-qna-answer/response-body.adoc[]
+
+=== 7. QNA 답변 수성
+.request
+include::{snippets}/qna-answer-controller-test/success_update-qna-answer/http-request.adoc[]
+
+.response
+include::{snippets}/qna-answer-controller-test/success_update-qna-answer/http-response.adoc[]
+
+.response field
+include::{snippets}/qna-answer-controller-test/success_update-qna-answer/response-body.adoc[]
+
 
 == 유저
 === 1. 유저 팔로우 / 팔로우 취소

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    INVALID_QNA_ANSWER_STATUS("답변의 상태가 유효하지 않습니다."),
+    CHANGE_IMPOSSIBLE_PINNED_ANSWER("고정된 답글은 수정하거나 삭제할 수 없습니다."),
+    NOT_FOUND_QNA_ANSWER("존재하지 않는 답변입니다."),
     INVALID_POST_STATUS("게시글의 상태가 유효하지 않습니다."),
     INVALID_POST_TYPE_FOR_ANSWER("답변을 달기에 유효하지 않은 게시글 타입입니다."),
     NOT_FOUND_POST("존재하지 않는 게시물입니다."),

--- a/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
@@ -7,12 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.bud.jwt.TokenProvider;
 import zerobase.bud.post.dto.CreateQnaAnswer;
+import zerobase.bud.post.dto.UpdateQnaAnswer;
 import zerobase.bud.post.service.QnaAnswerService;
 
 @RestController
@@ -34,5 +36,12 @@ public class QnaAnswerController {
                 , request
             )
         );
+    }
+
+    @PutMapping
+    public ResponseEntity<Long> updateQnaAnswer(
+        @RequestBody @Valid UpdateQnaAnswer.Request request
+    ) {
+        return ResponseEntity.ok(qnaAnswerService.updateQnaAnswer(request));
     }
 }

--- a/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswerPin.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswerPin.java
@@ -1,21 +1,16 @@
 package zerobase.bud.post.domain;
 
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import zerobase.bud.domain.BaseEntity;
-import zerobase.bud.domain.Member;
-import zerobase.bud.post.type.QnaAnswerStatus;
 
 @Getter
 @Setter
@@ -23,7 +18,7 @@ import zerobase.bud.post.type.QnaAnswerStatus;
 @AllArgsConstructor
 @SuperBuilder
 @Entity
-public class QnaAnswer extends BaseEntity {
+public class QnaAnswerPin extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,19 +28,6 @@ public class QnaAnswer extends BaseEntity {
     private Post post;
 
     @ManyToOne
-    private Member member;
+    private QnaAnswer qnaAnswer;
 
-    @NotNull
-    private String content;
-
-    private long commentCount;
-
-    private long likeCount;
-
-    @Enumerated(EnumType.STRING)
-    private QnaAnswerStatus qnaAnswerStatus;
-
-    public void updateContent(String content) {
-        this.content = content;
-    }
 }

--- a/user-api/src/main/java/zerobase/bud/post/dto/UpdateQnaAnswer.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/UpdateQnaAnswer.java
@@ -1,0 +1,26 @@
+package zerobase.bud.post.dto;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UpdateQnaAnswer {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @NotNull
+        @Min(1)
+        private Long qnaAnswerId;
+
+        @NotNull
+        private String content;
+
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerPinRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerPinRepository.java
@@ -1,0 +1,13 @@
+package zerobase.bud.post.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.bud.post.domain.QnaAnswerPin;
+
+@Repository
+public interface QnaAnswerPinRepository extends
+    JpaRepository<QnaAnswerPin, Long> {
+
+    Optional<QnaAnswerPin> findByQnaAnswerId(Long qnaAnswerId);
+}

--- a/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
@@ -1,8 +1,11 @@
 package zerobase.bud.post.service;
 
+import static zerobase.bud.common.type.ErrorCode.CHANGE_IMPOSSIBLE_PINNED_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_STATUS;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_TYPE_FOR_ANSWER;
+import static zerobase.bud.common.type.ErrorCode.INVALID_QNA_ANSWER_STATUS;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_QNA_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.NOT_REGISTERED_GITHUB_USER_ID;
 
 import java.util.Objects;
@@ -15,7 +18,9 @@ import zerobase.bud.domain.GithubInfo;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.dto.CreateQnaAnswer.Request;
+import zerobase.bud.post.dto.UpdateQnaAnswer;
 import zerobase.bud.post.repository.PostRepository;
+import zerobase.bud.post.repository.QnaAnswerPinRepository;
 import zerobase.bud.post.repository.QnaAnswerRepository;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
@@ -32,6 +37,8 @@ public class QnaAnswerService {
     private final PostRepository postRepository;
 
     private final QnaAnswerRepository qnaAnswerRepository;
+
+    private final QnaAnswerPinRepository qnaAnswerPinRepository;
 
     @Transactional
     public String createQnaAnswer(String userId, Request request) {
@@ -55,13 +62,40 @@ public class QnaAnswerService {
         return userId;
     }
 
+    @Transactional
+    public Long updateQnaAnswer(UpdateQnaAnswer.Request request) {
+
+        QnaAnswer qnaAnswer = qnaAnswerRepository.findById(
+                request.getQnaAnswerId())
+            .orElseThrow(() -> new BudException(NOT_FOUND_QNA_ANSWER));
+
+        validateUpdateQnaAnswer(qnaAnswer, request);
+
+        qnaAnswer.updateContent(request.getContent());
+
+        return request.getQnaAnswerId();
+    }
+
+    private void validateUpdateQnaAnswer(QnaAnswer qnaAnswer, UpdateQnaAnswer.Request request) {
+
+        if (!Objects.equals(qnaAnswer.getQnaAnswerStatus(), QnaAnswerStatus.ACTIVE)) {
+            throw new BudException(INVALID_QNA_ANSWER_STATUS);
+        }
+
+        qnaAnswerPinRepository.findByQnaAnswerId(request.getQnaAnswerId())
+            .ifPresent(ap -> {
+                throw new BudException(CHANGE_IMPOSSIBLE_PINNED_ANSWER);
+            });
+    }
+
     private void validateCreateQnaAnswer(Post post) {
-        if(!Objects.equals(post.getPostType(), PostType.QNA)){
+        if (!Objects.equals(post.getPostType(), PostType.QNA)) {
             throw new BudException(INVALID_POST_TYPE_FOR_ANSWER);
         }
 
-        if(!Objects.equals(post.getPostStatus(), PostStatus.ACTIVE)){
+        if (!Objects.equals(post.getPostStatus(), PostStatus.ACTIVE)) {
             throw new BudException(INVALID_POST_STATUS);
         }
     }
+
 }

--- a/user-api/src/test/java/zerobase/bud/github/service/GithubServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/github/service/GithubServiceTest.java
@@ -212,6 +212,7 @@ class GithubServiceTest {
             .nickname("nick")
             .level(getLevel())
             .userId("")
+            .createdAt(LocalDateTime.now().minusDays(1))
             .build();
     }
 

--- a/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +24,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import zerobase.bud.jwt.TokenProvider;
 import zerobase.bud.post.dto.CreateQnaAnswer;
+import zerobase.bud.post.dto.UpdateQnaAnswer;
 import zerobase.bud.post.service.QnaAnswerService;
 
 @WebMvcTest(QnaAnswerController.class)
@@ -60,6 +62,33 @@ class QnaAnswerControllerTest {
                 .content(objectMapper.writeValueAsString(
                     CreateQnaAnswer.Request.builder()
                         .postId(1L)
+                        .content("content")
+                        .build()
+                )).with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
+    }
+
+    @Test
+    @WithMockUser
+    void success_updateQnaAnswer() throws Exception {
+        //given
+        given(qnaAnswerService.updateQnaAnswer(any()))
+            .willReturn(3L);
+
+        //when
+        //then
+        mockMvc.perform(put("/posts/answer")
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    UpdateQnaAnswer.Request.builder()
+                        .qnaAnswerId(1L)
                         .content("content")
                         .build()
                 )).with(csrf()))


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - QnA에 대한 답변을 수정하는 기능을 구현하였으며 관련 실패응답 정책입니다.
      - 답변이 없는 경우
      - 답변의 상태가 ACTIVE가 아닌 경우
      - 해당 답변이 PIN인 경우 수정, 삭제 불가

- 변경 사항 2
   - 테스트
      - Local에서 포스트맨을 통해 요청과 응답을 확인하고 db의 변경사항을 확인
      - 테스트코드 작성

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 12. Wed`
