### PR TITLE
[Feat#53-AWS_S3_POST] AWS S3를 이용하여 게시글의 이미지 저장하는 기능

### DIFF
--- a/core/src/main/java/zerobase/bud/type/ErrorCode.java
+++ b/core/src/main/java/zerobase/bud/type/ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    INVALID_FILE_FORMAT("유효하지 않은 파일 형식입니다."),
     BATCH_JOB_FAILED("배치작업에 실패하였습니다"),
     NOT_REGISTERED_MEMBER("등록되지 않은 회원입니다."),
     FAILED_GET_COMMIT_INFO("커밋 정보를 가져오는 데 실패했습니다."),

--- a/core/src/main/java/zerobase/bud/util/Constants.java
+++ b/core/src/main/java/zerobase/bud/util/Constants.java
@@ -1,0 +1,12 @@
+package zerobase.bud.util;
+
+public class Constants {
+    public static final String FILE_EXTENSION_SEPARATOR = ".";
+    public static final String DIRECTORY_SEPARATOR = "/";
+    public static final String FILE_NAME_SEPARATOR = "_";
+    public static final String REPLACE_EXPRESSION = "-";
+    public static final String CHATS = "chats";
+    public static final String POSTS = "posts";
+    public static final String USERS = "users";
+
+}

--- a/core/src/main/java/zerobase/bud/util/FileUtil.java
+++ b/core/src/main/java/zerobase/bud/util/FileUtil.java
@@ -1,0 +1,47 @@
+package zerobase.bud.util;
+
+import static zerobase.bud.type.ErrorCode.INVALID_FILE_FORMAT;
+import static zerobase.bud.util.Constants.DIRECTORY_SEPARATOR;
+import static zerobase.bud.util.Constants.FILE_EXTENSION_SEPARATOR;
+import static zerobase.bud.util.Constants.FILE_NAME_SEPARATOR;
+import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.experimental.UtilityClass;
+import zerobase.bud.exception.BudException;
+
+@UtilityClass
+public class FileUtil {
+
+    public static String createFileName(String fileName) {
+        StringBuilder sb = new StringBuilder();
+        String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+        return sb.append(
+                UUID.randomUUID().toString().replaceAll(REPLACE_EXPRESSION, ""))
+                 .append(FILE_NAME_SEPARATOR)
+                 .append(now)
+                 .append(getFileExtension(fileName))
+                 .toString();
+    }
+
+    public static String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(
+                fileName.lastIndexOf(FILE_EXTENSION_SEPARATOR));
+        } catch (Exception e) {
+            throw new BudException(INVALID_FILE_FORMAT);
+        }
+    }
+
+    public static String createFilePath(String domain) {
+        StringBuilder sb = new StringBuilder();
+        return sb.append(domain)
+            .append(DIRECTORY_SEPARATOR)
+            .append(LocalDate.now())
+            .append(DIRECTORY_SEPARATOR)
+            .toString();
+    }
+}

--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'commons-io:commons-io:2.11.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     implementation "com.querydsl:querydsl-jpa:5.0.0"
     implementation "com.querydsl:querydsl-apt:5.0.0"

--- a/user-api/src/main/java/zerobase/bud/awss3/AwsS3Api.java
+++ b/user-api/src/main/java/zerobase/bud/awss3/AwsS3Api.java
@@ -1,0 +1,65 @@
+package zerobase.bud.awss3;
+
+import static zerobase.bud.common.type.ErrorCode.FAILED_UPLOAD_FILE;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import zerobase.bud.common.exception.BudException;
+import zerobase.bud.util.FileUtil;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Api {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    public String uploadImage(
+        MultipartFile multipartFile
+        , String domain
+    ) {
+        log.info("uploadImage started " + LocalDateTime.now());
+        String filePath = FileUtil.createFilePath(domain);
+        String fileName = FileUtil.createFileName(
+            multipartFile.getOriginalFilename());
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(
+                new PutObjectRequest(bucket, filePath + fileName, inputStream,
+                    objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new BudException(FAILED_UPLOAD_FILE);
+        }
+        log.info("uploadImage finished " + LocalDateTime.now() + " ImagePath : "
+            + filePath + fileName);
+        return filePath + fileName;
+    }
+
+    public String getImageUrl(String ImagePath) {
+        return amazonS3Client.getUrl(bucket, ImagePath).toString();
+    }
+
+    public void deleteImage(String ImagePath) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, ImagePath));
+    }
+
+
+}

--- a/user-api/src/main/java/zerobase/bud/common/exception/GlobalExceptionHandler.java
+++ b/user-api/src/main/java/zerobase/bud/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package zerobase.bud.common.exception;
 
+import static zerobase.bud.common.type.ErrorCode.AWS_S3_ERROR;
 import static zerobase.bud.common.type.ErrorCode.INTERNAL_ERROR;
 import static zerobase.bud.common.type.ErrorCode.WRONG_REQUEST_TYPE_ERROR;
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -13,6 +15,15 @@ import zerobase.bud.common.dto.ErrorResponse;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AmazonS3Exception.class)
+    public ResponseEntity<ErrorResponse> handleAmazonS3Exception(AmazonS3Exception ae){
+        log.error("AWS S3 Exception is occurred" , ae);
+        return ResponseEntity.internalServerError().body(ErrorResponse.builder()
+                .errorCode(AWS_S3_ERROR)
+                .message(ae.getMessage())
+            .build());
+    }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException he){

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    AWS_S3_ERROR("AWS S3 오류입니다."),
     INVALID_POST_STATUS("게시글의 상태가 유효하지 않습니다."),
     INVALID_POST_TYPE_FOR_ANSWER("답변을 달기에 유효하지 않은 게시글 타입입니다."),
+    FAILED_UPLOAD_FILE("파일 업로드에 실패하였습니다"),
     NOT_FOUND_POST("존재하지 않는 게시물입니다."),
     INVALID_INITIAL_VALUE("잘못된 초기값입니다."),
     INVALID_TOTAL_COMMIT_COUNT("유효하지 않은 총 커밋 수 입니다."),

--- a/user-api/src/main/java/zerobase/bud/config/AwsS3Config.java
+++ b/user-api/src/main/java/zerobase/bud/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package zerobase.bud.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredits = new BasicAWSCredentials(accessKey,
+            secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredits))
+            .build();
+    }
+
+}

--- a/user-api/src/main/java/zerobase/bud/post/domain/Image.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/Image.java
@@ -27,6 +27,6 @@ public class Image extends BaseEntity {
     @ManyToOne
     private Post post;
 
-    private String imageUrl;
+    private String imagePath;
 
 }

--- a/user-api/src/main/java/zerobase/bud/post/dto/PostDto.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/PostDto.java
@@ -3,7 +3,6 @@ package zerobase.bud.post.dto;
 import lombok.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.security.core.parameters.P;
 import zerobase.bud.post.domain.Image;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.repository.ImageRepository;
@@ -41,7 +40,7 @@ public class PostDto {
         String[] imageUrls = new String[images.size()];
 
         for (int i = 0; i < images.size(); i++) {
-            imageUrls[i] = images.get(0).getImageUrl();
+            imageUrls[i] = images.get(0).getImagePath();
         }
 
         return PostDto.builder()

--- a/user-api/src/main/java/zerobase/bud/post/service/PostService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/PostService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import zerobase.bud.awss3.AwsS3Api;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.GithubInfo;
 import zerobase.bud.post.domain.Image;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
 import static zerobase.bud.common.type.ErrorCode.NOT_REGISTERED_MEMBER;
 import static zerobase.bud.post.type.PostStatus.ACTIVE;
+import static zerobase.bud.util.Constants.POSTS;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -41,6 +43,8 @@ public class PostService {
     private final ImageRepository imageRepository;
 
     private final PostRepositoryQuerydslImpl postRepositoryQuerydsl;
+
+    private final AwsS3Api awsS3Api;
 
     @Transactional
     public String createPost(String userId, List<MultipartFile> images,
@@ -58,12 +62,8 @@ public class PostService {
             .build());
 
         if (Objects.nonNull(images)) {
-            //TODO : S3 기능 구현 후 로직 수정
             for (MultipartFile image : images) {
-                imageRepository.save(Image.builder()
-                    .post(post)
-                    .imageUrl(image.getOriginalFilename())
-                    .build());
+                saveImage(post, image);
             }
         }
 
@@ -80,21 +80,18 @@ public class PostService {
             .orElseThrow(() -> new BudException(NOT_FOUND_POST));
 
         post.update(request);
+
+        deleteImagesFromAwsS3(post.getId());
         imageRepository.deleteAllByPostId(post.getId());
 
         if (Objects.nonNull(images)) {
-            //TODO : S3 기능 구현 후 로직 수정
             for (MultipartFile image : images) {
-                imageRepository.save(Image.builder()
-                    .post(post)
-                    .imageUrl(image.getOriginalFilename())
-                    .build());
+                saveImage(post, image);
             }
         }
 
         return request.getTitle();
     }
-
 
     @Transactional(readOnly = true)
     public Page<PostDto> searchPosts(String keyword, PostSortType sort,
@@ -125,5 +122,20 @@ public class PostService {
         postRepository.save(post);
 
         return post.getId();
+    }
+
+    private void saveImage(Post post, MultipartFile image) {
+        String imagePath = awsS3Api.uploadImage(image, POSTS);
+        imageRepository.save(Image.builder()
+            .post(post)
+            .imagePath(imagePath)
+            .build());
+    }
+
+    private void deleteImagesFromAwsS3(Long postId) {
+        List<Image> imageList = imageRepository.findAllByPostId(postId);
+        for (Image image : imageList) {
+            awsS3Api.deleteImage(image.getImagePath());
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 
   - AWS S3를 이용하여 게시글의 이미지 저장하는 기능을 구축하였습니다.
   - 관련 정책
      - file은 budproject/posts(domain)/날짜/파일명(UUID_yyyyMMddHHmmssSSS).파일확장자로 S3에 저장됩니다.
      - UPDATE의 경우 기존의 게시글의 이미지 파일을 삭제 후 업로드 합니다.
      - AWS S3 관련 Excetion 추가
      - 관련 테스트 코드 수정


## Merge 전 필요 작업 (Checklist before merge)
- yml에 aws 관련 내용들을 추가해주셔야 합니다. (노션 - 백엔드 규칙에 넣어두었습니다.)
 
## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 12. Wed`

## 참고사항
- 도메인의 경우 현재 Constants에 POSTS , USERS, CHATS로 넣어두었습니다. 파일은 core모듈에 있습니다.
- Filutil 의 경우 다른 모듈에도 쓰일 수 있을 것 같아 core에 넣어두었습니다.
