### PR TITLE
[Feat#60-SendMessageByFcm] fcm을 이용해 메시지 송신 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 *.sql
 *.yml
+/**/budproject-da24e-firebase-adminsdk-r64ws-a4abd7f94d.json

--- a/batch-api/src/main/java/zerobase/bud/tasklet/GetCommitInfoTasklet.java
+++ b/batch-api/src/main/java/zerobase/bud/tasklet/GetCommitInfoTasklet.java
@@ -32,10 +32,14 @@ public class GetCommitInfoTasklet {
                     info.getUserId())
                 .orElseThrow(() -> new BudException(NOT_REGISTERED_MEMBER));
 
-            githubApi.saveCommitInfoFromLastCommitDate(
-                githubInfo
-                , LocalDate.now().minusDays(1)
-            );
+            try {
+                githubApi.saveCommitInfoFromLastCommitDate(
+                    githubInfo
+                    , LocalDate.now().minusDays(1)
+                );
+            } catch (Exception e) {
+                log.error(githubInfo.getUsername() + "님의 깃헙 연동에 실패하였습니다.");
+            }
         }
 
         log.info("complete getCommitInfo..." + LocalDateTime.now());

--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     implementation project(':core')
+    implementation 'com.google.firebase:firebase-admin:9.1.1'
 }
 
 tasks.named('test') {

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    NOT_FOUND_TOKEN("Firebase 토큰을 발견하지 못했습니다."),
+    FIREBASE_SEND_MESSAGE_FAILED("Firebase 메시지 전송에 실패하였습니다."),
+    FIREBASE_INIT_FAILED("Firebase 초기화에 실패하였습니다."),
     REQUEST_METHOD_OR_URL_ERROR("요청하신 메서드 혹은 주소가 잘못되었습니다."),
     AWS_S3_ERROR("AWS S3 오류입니다."),
     INVALID_QNA_ANSWER_STATUS("답변의 상태가 유효하지 않습니다."),

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    NOT_FOUND_NOTIFICATION_INFO("알림 정보가 없습니다."),
     NOT_FOUND_TOKEN("Firebase 토큰을 발견하지 못했습니다."),
     FIREBASE_SEND_MESSAGE_FAILED("Firebase 메시지 전송에 실패하였습니다."),
     FIREBASE_INIT_FAILED("Firebase 초기화에 실패하였습니다."),

--- a/user-api/src/main/java/zerobase/bud/config/FcmConfig.java
+++ b/user-api/src/main/java/zerobase/bud/config/FcmConfig.java
@@ -1,0 +1,46 @@
+package zerobase.bud.config;
+
+import static zerobase.bud.common.type.ErrorCode.FIREBASE_INIT_FAILED;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import zerobase.bud.common.exception.BudException;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.key.path}")
+    private String fcmPrivateKeyPath;
+
+    @Value("${fcm.key.scope}")
+    private List<String> fireBaseScope;
+
+    // fcm 기본 설정 진행
+    @PostConstruct
+    public void init() {
+        try {
+            FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(new ClassPathResource(
+                        fcmPrivateKeyPath).getInputStream())
+                    .createScoped(fireBaseScope))
+                .build();
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase application has been initialized");
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new BudException(FIREBASE_INIT_FAILED);
+        }
+    }
+
+}

--- a/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
+++ b/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
@@ -1,0 +1,75 @@
+package zerobase.bud.fcm;
+
+import static zerobase.bud.common.type.ErrorCode.FIREBASE_SEND_MESSAGE_FAILED;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_TOKEN;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import zerobase.bud.common.exception.BudException;
+import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.repository.NotificationRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FcmApi {
+
+    private final NotificationRepository notificationRepository;
+
+    //임시로 fcmToken 받도록 함.
+    //이 토큰의 주인이 알림을 받을 사람을 의미한다.
+    @Value("${fcm.temp.token}")
+    private String fcmTempToken;
+
+    public void sendNotificationByToken(NotificationDto dto) {
+//        String token = dto.getSender().getFCMToken();
+        String token = fcmTempToken;
+        if (Objects.nonNull(token)) {
+
+            WebpushConfig webpushConfig = WebpushConfig.builder()
+                .setNotification(
+                    new WebpushNotification(dto.getNotificationType().name()
+                        , dto.getNotificationDetailType().getMessage()))
+                .build();
+
+            // 메시지 만들기
+            Message message = Message.builder()
+                .setToken(token)
+                .setWebpushConfig(webpushConfig)
+                .putData("senderId", dto.getSender().getId().toString())
+                .putData("senderNickname", dto.getSender().getNickname())
+                .putData("notificationType", dto.getNotificationType().name())
+                .putData("pageType", dto.getPageType().name())
+                .putData("pageId", dto.getPageId().toString())
+                .putData("notificationDetailType",
+                    dto.getNotificationDetailType().name())
+                .putData("notifiedAt", dto.getNotifiedAt().toString())
+                .build();
+
+            // 요청에 대한 응답을 받을 response
+            try {
+                // 알림 발송
+                String response = FirebaseMessaging.getInstance().send(message);
+                log.info(response);
+
+                notificationRepository.save(Notification.from(dto));
+            } catch (FirebaseMessagingException e) {
+                log.error(
+                    "cannot send to memberList push message. error info : {}",
+                    e.getMessage());
+                throw new BudException(FIREBASE_SEND_MESSAGE_FAILED);
+            }
+        } else {
+            throw new BudException(NOT_FOUND_TOKEN);
+        }
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
+++ b/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
@@ -1,0 +1,48 @@
+package zerobase.bud.notification.controller;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zerobase.bud.domain.Member;
+import zerobase.bud.fcm.FcmApi;
+import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.service.NotificationService;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final FcmApi fcmApi;
+
+    //테스트용 알람쏴보기
+    @PostMapping
+    public ResponseEntity<String> sendTestNotification(
+        @AuthenticationPrincipal Member member
+    ){
+        fcmApi.sendNotificationByToken(NotificationDto.builder()
+                .sender(member)
+                .notificationType(NotificationType.POST)
+                .pageType(PageType.FEED)
+                .pageId(1L)
+                .notificationStatus(NotificationStatus.READ)
+                .notificationDetailType(NotificationDetailType.ANSWER)
+                .notifiedAt(LocalDateTime.now())
+            .build());
+
+        return ResponseEntity.ok("hi");
+    }
+    //get(알람 리스트 가져오기)
+    //알람 상태 변화 (안읽음 -> 읽음)
+    //알람 삭제(읽음 -> 삭제 or 안읽음 -> 삭제)
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
@@ -1,0 +1,66 @@
+package zerobase.bud.notification.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import zerobase.bud.domain.BaseEntity;
+import zerobase.bud.domain.Member;
+import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Member sender;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Enumerated(EnumType.STRING)
+    private PageType pageType;
+
+    private Long pageId;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationDetailType notificationDetailType;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationStatus notificationStatus;
+
+    private LocalDateTime notifiedAt;
+
+    public static Notification from(NotificationDto dto) {
+        return Notification.builder()
+            .sender(dto.getSender())
+            .notificationType(dto.getNotificationType())
+            .pageType(dto.getPageType())
+            .pageId(dto.getPageId())
+            .notificationDetailType(dto.getNotificationDetailType())
+            .notificationStatus(dto.getNotificationStatus())
+            .notifiedAt(dto.getNotifiedAt())
+            .build();
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
@@ -1,6 +1,7 @@
 package zerobase.bud.notification.domain;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -36,6 +37,9 @@ public class Notification extends BaseEntity {
     @ManyToOne
     private Member sender;
 
+    @Column(unique = true)
+    private String notificationId;
+
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
 
@@ -52,9 +56,10 @@ public class Notification extends BaseEntity {
 
     private LocalDateTime notifiedAt;
 
-    public static Notification from(NotificationDto dto) {
+    public static Notification of(String notificationId, NotificationDto dto) {
         return Notification.builder()
             .sender(dto.getSender())
+            .notificationId(notificationId)
             .notificationType(dto.getNotificationType())
             .pageType(dto.getPageType())
             .pageId(dto.getPageId())

--- a/user-api/src/main/java/zerobase/bud/notification/domain/NotificationInfo.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/NotificationInfo.java
@@ -1,0 +1,38 @@
+package zerobase.bud.notification.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import zerobase.bud.domain.BaseEntity;
+import zerobase.bud.domain.Member;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+public class NotificationInfo extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private Member member;
+
+    private String fcmToken;
+
+    private boolean isPostPushAvailable;
+
+    private boolean isFollowPushAvailable;
+
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
@@ -1,0 +1,35 @@
+package zerobase.bud.notification.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import zerobase.bud.domain.Member;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationDto {
+
+    private Member sender;
+
+    private NotificationType notificationType;
+
+    private PageType pageType;
+
+    private Long pageId;
+
+    private NotificationDetailType notificationDetailType;
+
+    private NotificationStatus notificationStatus;
+
+    private LocalDateTime notifiedAt;
+}

--- a/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
@@ -1,6 +1,7 @@
 package zerobase.bud.notification.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,8 @@ import zerobase.bud.notification.type.PageType;
 @NoArgsConstructor
 @Builder
 public class NotificationDto {
+
+    private List<String> tokens;
 
     private Member sender;
 

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
@@ -1,0 +1,13 @@
+package zerobase.bud.notification.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.bud.notification.domain.NotificationInfo;
+
+@Repository
+public interface NotificationInfoRepository extends
+    JpaRepository<NotificationInfo, Long> {
+
+    Optional<NotificationInfo> findByMemberId(Long memberId);
+}

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package zerobase.bud.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.bud.notification.domain.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
@@ -1,0 +1,15 @@
+package zerobase.bud.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    //notification save
+    //event
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/type/NotificationDetailType.java
+++ b/user-api/src/main/java/zerobase/bud/notification/type/NotificationDetailType.java
@@ -1,0 +1,17 @@
+package zerobase.bud.notification.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationDetailType {
+    FOLLOWED("다른 사용자가 팔로우하였습니다."),
+    NEW_POST("팔로우한 사용자가 새로운 게시물을 작성했습니다."),
+    COMMENT("게시글에 댓글이 달렸습니다."),
+    LIKE("좋아요가 눌렸습니다."),
+    ANSWER("답글이 달렸습니다."),
+    PIN("고정되었습니다");
+
+    private final String message;
+}

--- a/user-api/src/main/java/zerobase/bud/notification/type/NotificationStatus.java
+++ b/user-api/src/main/java/zerobase/bud/notification/type/NotificationStatus.java
@@ -1,0 +1,7 @@
+package zerobase.bud.notification.type;
+
+public enum NotificationStatus {
+    READ,
+    DELETED,
+    UNREAD
+}

--- a/user-api/src/main/java/zerobase/bud/notification/type/NotificationType.java
+++ b/user-api/src/main/java/zerobase/bud/notification/type/NotificationType.java
@@ -1,0 +1,5 @@
+package zerobase.bud.notification.type;
+
+public enum NotificationType {
+    FOLLOW, POST
+}

--- a/user-api/src/main/java/zerobase/bud/notification/type/PageType.java
+++ b/user-api/src/main/java/zerobase/bud/notification/type/PageType.java
@@ -1,0 +1,7 @@
+package zerobase.bud.notification.type;
+
+public enum PageType {
+    OTHER_PROFILE,
+    QNA,
+    FEED
+}

--- a/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
@@ -4,10 +4,12 @@ import static zerobase.bud.common.type.ErrorCode.CHANGE_IMPOSSIBLE_PINNED_ANSWER
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_STATUS;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_TYPE_FOR_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.INVALID_QNA_ANSWER_STATUS;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_QNA_ANSWER;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
 import zerobase.bud.fcm.FcmApi;
+import zerobase.bud.notification.domain.NotificationInfo;
 import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.repository.NotificationInfoRepository;
 import zerobase.bud.notification.type.NotificationDetailType;
 import zerobase.bud.notification.type.NotificationStatus;
 import zerobase.bud.notification.type.NotificationType;
@@ -45,6 +49,8 @@ public class QnaAnswerService {
 
     private final QnaAnswerPinRepository qnaAnswerPinRepository;
 
+    private final NotificationInfoRepository notificationInfoRepository;
+
     @Transactional
     public String createQnaAnswer(Member member, Request request) {
 
@@ -61,15 +67,22 @@ public class QnaAnswerService {
             .build());
 
         post.plusCommentCount();
+        //TODO: 추후 토큰 관련 로직들이 생기면 작성
+        NotificationInfo notificationInfo = notificationInfoRepository.findByMemberId(
+                post.getMember().getId())
+            .orElseThrow(() -> new BudException(NOT_FOUND_NOTIFICATION_INFO));
 
-        sendNotification(member, post);
+        if (notificationInfo.isPostPushAvailable()) {
+            sendNotification(notificationInfo.getFcmToken(), member, post);
+        }
 
         return member.getUserId();
     }
 
-    private void sendNotification(Member member, Post post) {
+    private void sendNotification(String token, Member sender, Post post) {
         fcmApi.sendNotificationByToken(NotificationDto.builder()
-            .sender(member)
+            .tokens(List.of(token))
+            .sender(sender)
             .notificationType(NotificationType.POST)
             .pageType(PageType.QNA)
             .pageId(post.getId())

--- a/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
@@ -28,6 +28,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Level;
 import zerobase.bud.domain.Member;
+import zerobase.bud.fcm.FcmApi;
+import zerobase.bud.notification.domain.NotificationInfo;
+import zerobase.bud.notification.repository.NotificationInfoRepository;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.domain.QnaAnswerPin;
@@ -51,6 +54,12 @@ class QnaAnswerServiceTest {
     @Mock
     private QnaAnswerPinRepository qnaAnswerPinRepository;
 
+    @Mock
+    private NotificationInfoRepository notificationInfoRepository;
+
+    @Mock
+    private FcmApi fcmApi;
+
     @InjectMocks
     private QnaAnswerService qnaAnswerService;
 
@@ -63,6 +72,9 @@ class QnaAnswerServiceTest {
 
         given(qnaAnswerRepository.save(any()))
             .willReturn(getQnaAnswer());
+
+        given(notificationInfoRepository.findByMemberId(getMember().getId()))
+            .willReturn(Optional.ofNullable(getNotificationInfo()));
 
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(
             QnaAnswer.class);
@@ -83,6 +95,15 @@ class QnaAnswerServiceTest {
             captor.getValue().getQnaAnswerStatus());
         assertEquals("userId", answer);
 
+    }
+
+    private NotificationInfo getNotificationInfo() {
+        return NotificationInfo.builder()
+            .member(getMember())
+            .fcmToken("fcmToken")
+            .isPostPushAvailable(true)
+            .isFollowPushAvailable(true)
+            .build();
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - fcm을 이용해 알림 메시지 송신 기능 구현(테스트 적용 + qna답글 작성에 적용해보았고 전송 성공하였습니다.)
- 변경 사항 2
   - fcm 정책 관련 수정 (notificationId를 따로 uuid + 시분초로 만들어 알림 보낼 때 전송 ( 프론트 개발자분들 요청))

## Merge 전 필요 작업 (Checklist before merge)
- yml 쪽 변경이 필요합니다 자세한 사항은 저희 팀 노션의 백엔드 규칙에 올려두었습니다.
   또한 json(서버 비공개키)파일을 금일 배포 예정입니다. 그 파일은 resources에 업로드 하시면 됩니다.
## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 14. Fri`

## 참고사항
FcmApi Test코드를 만들어서 진행해보았으나 실패하여서 같이 올리진 못했습니다. 다음 PR로 올릴 수 있도록 노력해보겠습니다!
