### PR TITLE
feat#77: CustomOAuth2UserService 단 GitHubInfo 개체 생성 및 수정 기능 추가

### DIFF
--- a/core/src/main/java/zerobase/bud/domain/Member.java
+++ b/core/src/main/java/zerobase/bud/domain/Member.java
@@ -51,8 +51,8 @@ public class Member extends BaseEntity implements UserDetails {
     private String oAuthAccessToken;
     private boolean addInfoYn;
 
-    public Member update(String oAuthAccessToken) {
-        this.oAuthAccessToken = oAuthAccessToken;
+    public Member update(String nickname) {
+        this.nickname = nickname;
 
         return this;
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- 신규 가입 시 Member 개체 생성과 동시에 GithubInfo 개체 생성
- 이미 있는 회원일 시 OAuth Access Token과 Username 갱신

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
