### PR TITLE
[Feat-GetNotifications] 알림 리스트를 보여주는 기능

### DIFF
--- a/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
+++ b/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
@@ -37,13 +37,14 @@ public class FcmApi {
     public void sendNotificationByToken(NotificationDto dto) {
         //TODO: 토큰 값이 정상적으로 채워지면 로직 수정
 //        List<String> tokens = dto.getTokens();
+//        String token = tokens.get(0);
         String token = fcmTempToken;
         if (Objects.nonNull(token)) {
 
             WebpushConfig webpushConfig = WebpushConfig.builder()
-                .setNotification( new WebpushNotification(
-                        dto.getNotificationType().name()
-                        , dto.getNotificationDetailType().getMessage())).build();
+                .setNotification(new WebpushNotification(
+                    dto.getNotificationType().name()
+                    , dto.getNotificationDetailType().getMessage())).build();
 
             String now = LocalDateTime.now()
                 .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));

--- a/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
+++ b/user-api/src/main/java/zerobase/bud/fcm/FcmApi.java
@@ -41,13 +41,13 @@ public class FcmApi {
         if (Objects.nonNull(token)) {
 
             WebpushConfig webpushConfig = WebpushConfig.builder()
-                .setNotification(
-                    new WebpushNotification(dto.getNotificationType().name()
-                        , dto.getNotificationDetailType().getMessage()))
-                .build();
+                .setNotification( new WebpushNotification(
+                        dto.getNotificationType().name()
+                        , dto.getNotificationDetailType().getMessage())).build();
 
             String now = LocalDateTime.now()
                 .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+
             String notificationId = UUID.randomUUID().toString()
                 .replaceAll(REPLACE_EXPRESSION, "")
                 .concat(now);

--- a/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
+++ b/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
@@ -1,47 +1,33 @@
 package zerobase.bud.notification.controller;
 
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.bud.domain.Member;
-import zerobase.bud.fcm.FcmApi;
-import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.dto.GetNotifications;
 import zerobase.bud.notification.service.NotificationService;
-import zerobase.bud.notification.type.NotificationDetailType;
-import zerobase.bud.notification.type.NotificationStatus;
-import zerobase.bud.notification.type.NotificationType;
-import zerobase.bud.notification.type.PageType;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/notification")
+@RequestMapping("/notifications")
 public class NotificationController {
 
     private final NotificationService notificationService;
-    private final FcmApi fcmApi;
 
-    //테스트용 알람쏴보기
-    @PostMapping
-    public ResponseEntity<String> sendTestNotification(
-        @AuthenticationPrincipal Member member
-    ){
-        fcmApi.sendNotificationByToken(NotificationDto.builder()
-                .sender(member)
-                .notificationType(NotificationType.POST)
-                .pageType(PageType.FEED)
-                .pageId(1L)
-                .notificationStatus(NotificationStatus.READ)
-                .notificationDetailType(NotificationDetailType.ANSWER)
-                .notifiedAt(LocalDateTime.now())
-            .build());
-
-        return ResponseEntity.ok("hi");
-    }
     //get(알람 리스트 가져오기)
+    @GetMapping
+    public Slice<GetNotifications.Response> getNotifications(
+        @AuthenticationPrincipal Member member,
+        @PageableDefault(sort = "notifiedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return notificationService.getNotifications(member, pageable);
+    }
     //알람 상태 변화 (안읽음 -> 읽음)
     //알람 삭제(읽음 -> 삭제 or 안읽음 -> 삭제)
 

--- a/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
@@ -35,6 +35,9 @@ public class Notification extends BaseEntity {
     private Long id;
 
     @ManyToOne
+    private Member receiver;
+
+    @ManyToOne
     private Member sender;
 
     @Column(unique = true)
@@ -58,6 +61,7 @@ public class Notification extends BaseEntity {
 
     public static Notification of(String notificationId, NotificationDto dto) {
         return Notification.builder()
+            .receiver(dto.getReceiver())
             .sender(dto.getSender())
             .notificationId(notificationId)
             .notificationType(dto.getNotificationType())

--- a/user-api/src/main/java/zerobase/bud/notification/dto/GetNotifications.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/GetNotifications.java
@@ -1,0 +1,55 @@
+package zerobase.bud.notification.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+public class GetNotifications {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private String senderNickName;
+
+        private String notificationId;
+
+        private NotificationType notificationType;
+
+        private PageType pageType;
+
+        private Long pageId;
+
+        private NotificationDetailType notificationDetailType;
+
+        private NotificationStatus notificationStatus;
+
+        private LocalDateTime notifiedAt;
+
+        public static Response fromEntity(Notification notification) {
+            return Response.builder()
+                .senderNickName(notification.getSender().getNickname())
+                .notificationId(notification.getNotificationId())
+                .notificationType(notification.getNotificationType())
+                .pageType(notification.getPageType())
+                .pageId(notification.getPageId())
+                .notificationDetailType(
+                    notification.getNotificationDetailType())
+                .notificationStatus(notification.getNotificationStatus())
+                .notifiedAt(notification.getNotifiedAt())
+                .build();
+        }
+    }
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
@@ -22,6 +22,8 @@ public class NotificationDto {
 
     private List<String> tokens;
 
+    private Member receiver;
+
     private Member sender;
 
     private NotificationType notificationType;

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
@@ -1,10 +1,19 @@
 package zerobase.bud.notification.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.type.NotificationStatus;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends
+    JpaRepository<Notification, Long> {
 
+    Slice<Notification> findAllByReceiverIdAndNotificationStatusNot(
+        Long id
+        , NotificationStatus deleted
+        , Pageable pageable
+    );
 }

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import zerobase.bud.domain.Member;
-import zerobase.bud.notification.domain.Notification;
 import zerobase.bud.notification.dto.GetNotifications.Response;
 import zerobase.bud.notification.repository.NotificationRepository;
 import zerobase.bud.notification.type.NotificationStatus;
@@ -19,13 +18,12 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     public Slice<Response> getNotifications(Member member, Pageable pageable) {
-        Slice<Notification> notifications = notificationRepository
+        return notificationRepository
             .findAllByReceiverIdAndNotificationStatusNot(
                 member.getId()
                 , NotificationStatus.DELETED
-                , pageable);
-
-        return notifications.map(Response::fromEntity);
+                , pageable)
+            .map(Response::fromEntity);
     }
 
 }

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
@@ -2,14 +2,30 @@ package zerobase.bud.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import zerobase.bud.domain.Member;
+import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.dto.GetNotifications.Response;
+import zerobase.bud.notification.repository.NotificationRepository;
+import zerobase.bud.notification.type.NotificationStatus;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
-    //notification save
-    //event
+    private final NotificationRepository notificationRepository;
+
+    public Slice<Response> getNotifications(Member member, Pageable pageable) {
+        Slice<Notification> notifications = notificationRepository
+            .findAllByReceiverIdAndNotificationStatusNot(
+                member.getId()
+                , NotificationStatus.DELETED
+                , pageable);
+
+        return notifications.map(Response::fromEntity);
+    }
 
 }

--- a/user-api/src/test/java/zerobase/bud/notification/controller/NotificationControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,109 @@
+package zerobase.bud.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import zerobase.bud.jwt.TokenProvider;
+import zerobase.bud.notification.dto.GetNotifications;
+import zerobase.bud.notification.service.NotificationService;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureRestDocs
+class NotificationControllerTest {
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final static String TOKEN = "BEARER TOKEN";
+
+    @Test
+    @WithMockUser
+    void success_getNotifications() throws Exception {
+        //given
+        String now = LocalDateTime.now()
+            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+
+        String notificationId = UUID.randomUUID().toString()
+            .replaceAll(REPLACE_EXPRESSION, "")
+            .concat(now);
+
+        given(notificationService.getNotifications(any(), any()))
+            .willReturn(new SliceImpl<>(
+                    List.of(GetNotifications.Response.builder()
+                        .senderNickName("nickName")
+                        .notificationId(notificationId)
+                        .notificationType(NotificationType.POST)
+                        .pageType(PageType.QNA)
+                        .pageId(1L)
+                        .notificationDetailType(NotificationDetailType.ANSWER)
+                        .notificationStatus(NotificationStatus.UNREAD)
+                        .notifiedAt(LocalDateTime.now())
+                        .build())
+                )
+            );
+
+        //when 어떤 경우에
+        //then 이런 결과가 나온다.
+        mockMvc.perform(get("/notifications")
+                .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("$.content.[0].senderNickName").value("nickName"))
+            .andExpect(
+                jsonPath("$.content.[0].notificationId").value(notificationId))
+            .andExpect(jsonPath("$.content.[0].notificationType").value("POST"))
+            .andExpect(jsonPath("$.content.[0].pageType").value("QNA"))
+            .andExpect(jsonPath("$.content.[0].pageId").value(1))
+            .andExpect(jsonPath("$.content.[0].notificationDetailType").value(
+                "ANSWER"))
+            .andExpect(
+                jsonPath("$.content.[0].notificationStatus").value("UNREAD"))
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
+
+    }
+}

--- a/user-api/src/test/java/zerobase/bud/notification/service/NotificationServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/service/NotificationServiceTest.java
@@ -1,0 +1,102 @@
+package zerobase.bud.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import zerobase.bud.domain.Member;
+import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.dto.GetNotifications.Response;
+import zerobase.bud.notification.repository.NotificationRepository;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void success_getNotifications() {
+        //given
+        String now = LocalDateTime.now()
+            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+
+        String notificationId = UUID.randomUUID().toString()
+            .replaceAll(REPLACE_EXPRESSION, "")
+            .concat(now);
+
+        given(
+            notificationRepository.findAllByReceiverIdAndNotificationStatusNot(
+                getReceiver().getId(), NotificationStatus.DELETED,
+                Pageable.ofSize(1)
+            )).willReturn(
+            new SliceImpl<>(
+                List.of(Notification.builder()
+                    .receiver(getReceiver())
+                    .sender(getSender())
+                    .notificationId(notificationId)
+                    .notificationType(NotificationType.POST)
+                    .pageType(PageType.QNA)
+                    .pageId(1L)
+                    .notificationDetailType(NotificationDetailType.ANSWER)
+                    .notificationStatus(NotificationStatus.UNREAD)
+                    .notifiedAt(LocalDateTime.now())
+                    .build())
+            )
+        );
+        //when
+        Slice<Response> notifications = notificationService.getNotifications(
+            getReceiver(), Pageable.ofSize(1));
+        //then
+        Response notificationResponse = notifications.getContent().get(0);
+        assertEquals("sender", notificationResponse.getSenderNickName());
+
+        assertEquals(notificationId, notificationResponse.getNotificationId());
+
+        assertEquals(NotificationType.POST,
+            notificationResponse.getNotificationType());
+        assertEquals(PageType.QNA, notificationResponse.getPageType());
+        assertEquals(1L, notificationResponse.getPageId());
+        assertEquals(NotificationDetailType.ANSWER,
+            notificationResponse.getNotificationDetailType());
+        assertEquals(NotificationStatus.UNREAD,
+            notificationResponse.getNotificationStatus());
+    }
+
+    private Member getReceiver() {
+        return Member.builder()
+            .id(1L)
+            .nickname("receiver")
+            .userId("receiver")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+
+    private Member getSender() {
+        return Member.builder()
+            .id(2L)
+            .nickname("sender")
+            .userId("sender")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+}

--- a/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
@@ -11,8 +11,10 @@ import static zerobase.bud.common.type.ErrorCode.CHANGE_IMPOSSIBLE_PINNED_ANSWER
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_STATUS;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_TYPE_FOR_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.INVALID_QNA_ANSWER_STATUS;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_QNA_ANSWER;
+import static zerobase.bud.common.type.ErrorCode.NOT_REGISTERED_MEMBER;
 import static zerobase.bud.post.type.PostStatus.ACTIVE;
 import static zerobase.bud.post.type.PostStatus.INACTIVE;
 
@@ -26,7 +28,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import zerobase.bud.common.exception.BudException;
-import zerobase.bud.domain.Level;
 import zerobase.bud.domain.Member;
 import zerobase.bud.fcm.FcmApi;
 import zerobase.bud.notification.domain.NotificationInfo;
@@ -41,6 +42,7 @@ import zerobase.bud.post.repository.QnaAnswerPinRepository;
 import zerobase.bud.post.repository.QnaAnswerRepository;
 import zerobase.bud.post.type.PostType;
 import zerobase.bud.post.type.QnaAnswerStatus;
+import zerobase.bud.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
 class QnaAnswerServiceTest {
@@ -58,6 +60,9 @@ class QnaAnswerServiceTest {
     private NotificationInfoRepository notificationInfoRepository;
 
     @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
     private FcmApi fcmApi;
 
     @InjectMocks
@@ -73,14 +78,17 @@ class QnaAnswerServiceTest {
         given(qnaAnswerRepository.save(any()))
             .willReturn(getQnaAnswer());
 
-        given(notificationInfoRepository.findByMemberId(getMember().getId()))
+        given(notificationInfoRepository.findByMemberId(getSender().getId()))
             .willReturn(Optional.ofNullable(getNotificationInfo()));
+
+        given(memberRepository.findById(anyLong()))
+            .willReturn(Optional.ofNullable(getReceiver()));
 
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(
             QnaAnswer.class);
 
         //when
-        String answer = qnaAnswerService.createQnaAnswer(getMember(),
+        String answer = qnaAnswerService.createQnaAnswer(getSender(),
             Request.builder()
                 .postId(1L)
                 .content("content")
@@ -93,13 +101,13 @@ class QnaAnswerServiceTest {
         assertEquals("content", captor.getValue().getContent());
         assertEquals(QnaAnswerStatus.ACTIVE,
             captor.getValue().getQnaAnswerStatus());
-        assertEquals("userId", answer);
+        assertEquals("sender", answer);
 
     }
 
     private NotificationInfo getNotificationInfo() {
         return NotificationInfo.builder()
-            .member(getMember())
+            .member(getSender())
             .fcmToken("fcmToken")
             .isPostPushAvailable(true)
             .isFollowPushAvailable(true)
@@ -115,7 +123,7 @@ class QnaAnswerServiceTest {
 
         //when 어떤 경우에
         BudException budException = assertThrows(BudException.class,
-            () -> qnaAnswerService.createQnaAnswer(getMember(),
+            () -> qnaAnswerService.createQnaAnswer(getSender(),
                 Request.builder()
                     .postId(1L)
                     .content("content")
@@ -129,7 +137,7 @@ class QnaAnswerServiceTest {
     void INVALID_POST_TYPE_FOR_ANSWER_createQnaAnswer() {
         //given 어떤 데이터가 주어졌을 때
         Post post = Post.builder()
-            .member(getMember())
+            .member(getSender())
             .title("title")
             .content("postContent")
             .postStatus(ACTIVE)
@@ -141,7 +149,7 @@ class QnaAnswerServiceTest {
 
         //when 어떤 경우에
         BudException budException = assertThrows(BudException.class,
-            () -> qnaAnswerService.createQnaAnswer(getMember(),
+            () -> qnaAnswerService.createQnaAnswer(getSender(),
                 Request.builder()
                     .postId(1L)
                     .content("content")
@@ -155,7 +163,7 @@ class QnaAnswerServiceTest {
     void INVALID_POST_STATUS_createQnaAnswer() {
         //given 어떤 데이터가 주어졌을 때
         Post post = Post.builder()
-            .member(getMember())
+            .member(getSender())
             .title("title")
             .content("postContent")
             .postStatus(INACTIVE)
@@ -167,13 +175,68 @@ class QnaAnswerServiceTest {
 
         //when 어떤 경우에
         BudException budException = assertThrows(BudException.class,
-            () -> qnaAnswerService.createQnaAnswer(getMember(),
+            () -> qnaAnswerService.createQnaAnswer(getSender(),
                 Request.builder()
                     .postId(1L)
                     .content("content")
                     .build()));
         //then 이런 결과가 나온다.
         assertEquals(INVALID_POST_STATUS, budException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND_NOTIFICATION_INFO_createQnaAnswer")
+    void NOT_FOUND_NOTIFICATION_INFO_createQnaAnswer() {
+        //given
+
+        given(postRepository.findById(anyLong()))
+            .willReturn(Optional.ofNullable(getPost()));
+
+        given(qnaAnswerRepository.save(any()))
+            .willReturn(getQnaAnswer());
+
+        given(notificationInfoRepository.findByMemberId(getSender().getId()))
+            .willReturn(Optional.empty());
+
+        //when 어떤 경우에
+        BudException budException = assertThrows(BudException.class,
+            () -> qnaAnswerService.createQnaAnswer(getSender(),
+                Request.builder()
+                    .postId(1L)
+                    .content("content")
+                    .build()));
+        //then 이런 결과가 나온다.
+        assertEquals(NOT_FOUND_NOTIFICATION_INFO, budException.getErrorCode());
+
+    }
+
+    @Test
+    @DisplayName("NOT_REGISTERED_MEMBER_createQnaAnswer")
+    void NOT_REGISTERED_MEMBER_createQnaAnswer() {
+        //given
+
+        given(postRepository.findById(anyLong()))
+            .willReturn(Optional.ofNullable(getPost()));
+
+        given(qnaAnswerRepository.save(any()))
+            .willReturn(getQnaAnswer());
+
+        given(notificationInfoRepository.findByMemberId(getSender().getId()))
+            .willReturn(Optional.ofNullable(getNotificationInfo()));
+
+        given(memberRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
+
+        //when 어떤 경우에
+        BudException budException = assertThrows(BudException.class,
+            () -> qnaAnswerService.createQnaAnswer(getSender(),
+                Request.builder()
+                    .postId(1L)
+                    .content("content")
+                    .build()));
+        //then 이런 결과가 나온다.
+        assertEquals(NOT_REGISTERED_MEMBER, budException.getErrorCode());
+
     }
 
     @Test
@@ -219,7 +282,7 @@ class QnaAnswerServiceTest {
     void INVALID_QNA_ANSWER_STATUS_updateQnaAnswer() {
         //given 어떤 데이터가 주어졌을 때
         QnaAnswer qnaAnswer = QnaAnswer.builder()
-            .member(getMember())
+            .member(getSender())
             .post(getPost())
             .content("content")
             .qnaAnswerStatus(QnaAnswerStatus.INACTIVE)
@@ -271,7 +334,7 @@ class QnaAnswerServiceTest {
 
     private static QnaAnswer getQnaAnswer() {
         return QnaAnswer.builder()
-            .member(getMember())
+            .member(getSender())
             .post(getPost())
             .content("content")
             .qnaAnswerStatus(QnaAnswerStatus.ACTIVE)
@@ -280,7 +343,7 @@ class QnaAnswerServiceTest {
 
     private static Post getPost() {
         return Post.builder()
-            .member(getMember())
+            .member(getSender())
             .title("title")
             .content("postContent")
             .postStatus(ACTIVE)
@@ -288,21 +351,22 @@ class QnaAnswerServiceTest {
             .build();
     }
 
-    private static Member getMember() {
+    private static Member getSender() {
         return Member.builder()
-            .nickname("nick")
-            .level(getLevel())
-            .userId("userId")
+            .id(1L)
+            .nickname("sender")
+            .userId("sender")
             .createdAt(LocalDateTime.now().minusDays(1))
             .build();
     }
 
-    private static Level getLevel() {
-        return Level.builder()
-            .levelCode("씩씩한_새싹")
-            .levelStartCommitCount(0)
-            .nextLevelStartCommitCount(17)
-            .levelNumber(1)
+    private static Member getReceiver() {
+        return Member.builder()
+            .id(2L)
+            .nickname("receiver")
+            .userId("receiver")
+            .createdAt(LocalDateTime.now().minusDays(1))
             .build();
     }
+
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1 
   - Notification의 리스트들을 보여주는 기능 구현 
- 변경 사항 2
   - Notification에 Receiver(알림 수신자) 추가
- 변경 사항 2   
   - Notification의 리스트들을 보여주는 기능에 대한 테스트코드 구현

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 15. Sat`

##FcmApi 테스트의 경우!! 토큰을 가져오는 로직이 추후 수정되면 테스트 성공하는 것으로 확인하였습니다!!