### PR TITLE
[Feat-UpdateNotificationStatusRead] 알림상태를 읽음으로 변경하는 기능 구현

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -338,7 +338,7 @@ include::{snippets}/qna-answer-controller-test/success_create-qna-answer/http-re
 .response field
 include::{snippets}/qna-answer-controller-test/success_create-qna-answer/response-body.adoc[]
 
-=== 7. QNA 답변 수성
+=== 7. QNA 답변 수정
 .request
 include::{snippets}/qna-answer-controller-test/success_update-qna-answer/http-request.adoc[]
 
@@ -657,3 +657,24 @@ include::{snippets}/user-controller-test/success-delete-scrap/http-request.adoc[
 
 .response
 include::{snippets}/user-controller-test/success-delete-scrap/http-response.adoc[]
+
+== 알림 API
+=== 1. 알림 조회
+.request
+include::{snippets}/notification-controller-test/success_get-notifications/http-request.adoc[]
+
+.response
+include::{snippets}/notification-controller-test/success_get-notifications/http-response.adoc[]
+
+.response field
+include::{snippets}/notification-controller-test/success_get-notifications/response-fields.adoc[]
+
+=== 2. 알림 읽음으로 상태 변경
+.request
+include::{snippets}/notification-controller-test/success_update-notification-status-read/http-request.adoc[]
+
+.response
+include::{snippets}/notification-controller-test/success_update-notification-status-read/http-response.adoc[]
+
+.response field
+include::{snippets}/notification-controller-test/success_update-notification-status-read/response-body.adoc[]

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,13 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    AWS_S3_ERROR("AWS S3 오류입니다."),
+    NOT_RECEIVED_NOTIFICATION_MEMBER("알림을 수신한 회원이 아닙니다."),
+    DELETED_NOTIFICATION("삭제된 알람입니다."),
+    NOT_FOUND_NOTIFICATION("존재하지 않는 알림입니다."),
     NOT_FOUND_NOTIFICATION_INFO("알림 정보가 없습니다."),
     NOT_FOUND_TOKEN("Firebase 토큰을 발견하지 못했습니다."),
     FIREBASE_SEND_MESSAGE_FAILED("Firebase 메시지 전송에 실패하였습니다."),
     FIREBASE_INIT_FAILED("Firebase 초기화에 실패하였습니다."),
     REQUEST_METHOD_OR_URL_ERROR("요청하신 메서드 혹은 주소가 잘못되었습니다."),
-
+    AWS_S3_ERROR("AWS S3 오류입니다."),
     INVALID_QNA_ANSWER_STATUS("답변의 상태가 유효하지 않습니다."),
     CHANGE_IMPOSSIBLE_PINNED_ANSWER("고정된 답글은 수정하거나 삭제할 수 없습니다."),
     NOT_FOUND_QNA_ANSWER("존재하지 않는 답변입니다."),

--- a/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
+++ b/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
@@ -5,8 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.bud.domain.Member;
@@ -20,15 +23,25 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    //get(알람 리스트 가져오기)
+    private final static String SORTING_CRITERIA = "notifiedAt";
+
     @GetMapping
-    public Slice<GetNotifications.Response> getNotifications(
+    public ResponseEntity<Slice<GetNotifications.Response>> getNotifications(
         @AuthenticationPrincipal Member member,
-        @PageableDefault(sort = "notifiedAt", direction = Sort.Direction.DESC) Pageable pageable
+        @PageableDefault(sort = SORTING_CRITERIA , direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return notificationService.getNotifications(member, pageable);
+        return ResponseEntity.ok(notificationService.getNotifications(member, pageable));
     }
-    //알람 상태 변화 (안읽음 -> 읽음)
+
+    @PutMapping("/{notificationId}/read")
+    public ResponseEntity<String> updateNotificationStatusRead(
+        @PathVariable String notificationId,
+        @AuthenticationPrincipal Member member
+    ){
+        return ResponseEntity
+            .ok(notificationService.updateNotificationStatusRead(notificationId, member));
+    }
+
     //알람 삭제(읽음 -> 삭제 or 안읽음 -> 삭제)
 
 }

--- a/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/Notification.java
@@ -72,4 +72,8 @@ public class Notification extends BaseEntity {
             .notifiedAt(dto.getNotifiedAt())
             .build();
     }
+
+    public void updateStatus() {
+        this.notificationStatus = NotificationStatus.READ;
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package zerobase.bud.notification.repository;
 
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,6 @@ public interface NotificationRepository extends
         , NotificationStatus deleted
         , Pageable pageable
     );
+
+    Optional<Notification> findByNotificationId(String notificationId);
 }

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
@@ -1,11 +1,19 @@
 package zerobase.bud.notification.service;
 
+import static zerobase.bud.common.type.ErrorCode.DELETED_NOTIFICATION;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION;
+import static zerobase.bud.common.type.ErrorCode.NOT_RECEIVED_NOTIFICATION_MEMBER;
+
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.domain.Notification;
 import zerobase.bud.notification.dto.GetNotifications.Response;
 import zerobase.bud.notification.repository.NotificationRepository;
 import zerobase.bud.notification.type.NotificationStatus;
@@ -26,4 +34,28 @@ public class NotificationService {
             .map(Response::fromEntity);
     }
 
+
+    @Transactional
+    public String updateNotificationStatusRead(String notificationId , Member member) {
+
+        Notification notification = notificationRepository.findByNotificationId(
+                notificationId)
+            .orElseThrow(() -> new BudException(NOT_FOUND_NOTIFICATION));
+
+        validateUpdateNotificationStatus(notification, member);
+
+        notification.updateStatus();
+
+        return notificationId;
+    }
+
+    private void validateUpdateNotificationStatus(Notification notification, Member member) {
+        if(Objects.equals(NotificationStatus.DELETED, notification.getNotificationStatus())){
+            throw new BudException(DELETED_NOTIFICATION);
+        }
+
+        if(!Objects.equals(notification.getReceiver().getId(), member.getId())){
+            throw new BudException(NOT_RECEIVED_NOTIFICATION_MEMBER);
+        }
+    }
 }

--- a/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
@@ -96,22 +96,22 @@ class PostServiceTest {
         //when 어떤 경우에
         String result = postService.createPost(getMember(), images,
             CreatePost.Request.builder()
-                .title("t")
-                .content("c")
+                .title("resultTitle")
+                .content("resultContent")
                 .postType(PostType.FEED)
                 .build());
 
         //then 이런 결과가 나온다.
         verify(postRepository, times(1)).save(captor.capture());
         verify(imageRepository, times(1)).save(imageCaptor.capture());
-        assertEquals("t", captor.getValue().getTitle());
-        assertEquals("c", captor.getValue().getContent());
+        assertEquals("resultTitle", captor.getValue().getTitle());
+        assertEquals("resultContent", captor.getValue().getContent());
         assertEquals(ACTIVE, captor.getValue().getPostStatus());
         assertEquals(PostType.FEED, captor.getValue().getPostType());
         assertEquals("awsS3Image", imageCaptor.getValue().getImagePath());
         assertEquals("title", imageCaptor.getValue().getPost().getTitle());
         assertEquals("content", imageCaptor.getValue().getPost().getContent());
-        assertEquals("t", result);
+        assertEquals("resultTitle", result);
     }
 
     @Test
@@ -127,18 +127,18 @@ class PostServiceTest {
         //when 어떤 경우에
         String result = postService.createPost(getMember(), images,
             CreatePost.Request.builder()
-                .title("t")
-                .content("c")
-                .postType(PostType.QNA)
+                .title("resultTitle")
+                .content("resultContent")
+                .postType(PostType.FEED)
                 .build());
 
         //then 이런 결과가 나온다.
         verify(postRepository, times(1)).save(captor.capture());
-        assertEquals("t", captor.getValue().getTitle());
-        assertEquals("c", captor.getValue().getContent());
+        assertEquals("resultTitle", captor.getValue().getTitle());
+        assertEquals("resultContent", captor.getValue().getContent());
         assertEquals(ACTIVE, captor.getValue().getPostStatus());
-        assertEquals(PostType.QNA, captor.getValue().getPostType());
-        assertEquals("t", result);
+        assertEquals(PostType.FEED, captor.getValue().getPostType());
+        assertEquals("resultTitle", result);
     }
 
     @Test
@@ -164,19 +164,19 @@ class PostServiceTest {
         String result = postService.updatePost(images,
             UpdatePost.Request.builder()
                 .postId(1L)
-                .title("t")
-                .content("c")
+                .title("resultTitle")
+                .content("resultContent")
                 .postType(PostType.QNA)
                 .build());
 
         //then 이런 결과가 나온다.
         verify(imageRepository, times(1)).save(imageCaptor.capture());
         assertEquals("awsS3Image", imageCaptor.getValue().getImagePath());
-        assertEquals("t", imageCaptor.getValue().getPost().getTitle());
-        assertEquals("c", imageCaptor.getValue().getPost().getContent());
+        assertEquals("resultTitle", imageCaptor.getValue().getPost().getTitle());
+        assertEquals("resultContent", imageCaptor.getValue().getPost().getContent());
         assertEquals(PostType.QNA,
             imageCaptor.getValue().getPost().getPostType());
-        assertEquals("t", result);
+        assertEquals("resultTitle", result);
     }
 
     @Test
@@ -191,8 +191,8 @@ class PostServiceTest {
             () -> postService.updatePost(getMockMultipartFiles(),
                 UpdatePost.Request.builder()
                     .postId(1L)
-                    .title("t")
-                    .content("c")
+                    .title("resultTitle")
+                    .content("resultContent")
                     .postType(PostType.FEED)
                     .build()));
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - 알림상태를 읽음으로 변경하는 기능 (이미 삭제된 알람이라면 실패응답)
- 변경 사항 2
   - 해당 기능에 대한 테스트코드 구현 
- 테스트
  - 테스트코드 & 포스트맨 이용
 
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 16. Mon`
