### PR TITLE
[Refactor-FcmApi] 알림 송신 기능 리팩토링

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -719,3 +719,25 @@ include::{snippets}/notification-controller-test/success_update-notification-sta
 
 .response field
 include::{snippets}/notification-controller-test/success_update-notification-status-read/response-body.adoc[]
+
+=== 3. 알림 삭제
+.request
+include::{snippets}/notification-controller-test/success_delete-notification/http-request.adoc[]
+
+.response
+include::{snippets}/notification-controller-test/success_delete-notification/http-response.adoc[]
+
+.response field
+include::{snippets}/notification-controller-test/success_delete-notification/response-body.adoc[]
+
+
+== 파이어베이스토큰 API
+=== 1. 파이어베이스토큰 저장
+.request
+include::{snippets}/notification-info-controller-test/success_save-notification-info/http-request.adoc[]
+
+.response
+include::{snippets}/notification-info-controller-test/success_save-notification-info/http-response.adoc[]
+
+.response field
+include::{snippets}/notification-info-controller-test/success_save-notification-info/response-body.adoc[]

--- a/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/NotificationDto.java
@@ -37,4 +37,26 @@ public class NotificationDto {
     private NotificationStatus notificationStatus;
 
     private LocalDateTime notifiedAt;
+
+    public static NotificationDto of(
+        String token
+        , Member receiver
+        , Member sender
+        , NotificationType notificationType
+        , PageType pageType
+        , Long pageId
+        , NotificationDetailType notificationDetailType
+    ){
+        return NotificationDto.builder()
+            .tokens(List.of(token))
+            .receiver(receiver)
+            .sender(sender)
+            .notificationType(notificationType)
+            .pageType(pageType)
+            .pageId(pageId)
+            .notificationDetailType(notificationDetailType)
+            .notificationStatus(NotificationStatus.UNREAD)
+            .notifiedAt(LocalDateTime.now())
+            .build();
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/notification/service/SendNotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/SendNotificationService.java
@@ -1,0 +1,100 @@
+package zerobase.bud.notification.service;
+
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import zerobase.bud.common.exception.BudException;
+import zerobase.bud.domain.Member;
+import zerobase.bud.fcm.FcmApi;
+import zerobase.bud.notification.domain.NotificationInfo;
+import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.repository.NotificationInfoRepository;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+import zerobase.bud.post.domain.Post;
+import zerobase.bud.user.domain.Follow;
+import zerobase.bud.user.repository.FollowRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SendNotificationService {
+
+    private final NotificationInfoRepository notificationInfoRepository;
+
+    private final FcmApi fcmApi;
+
+    private final FollowRepository followRepository;
+
+    public void sendCreatePostNotification(Member member, Post post) {
+        List<Member> followerList = followRepository.findByTarget(member)
+            .map(Follow::getMember)
+            .collect(Collectors.toList());
+
+        log.info("follower 가 " + followerList.size() + " 명 입니다. 알림 전송을 시작합니다.");
+
+        for (Member receiver : followerList) {
+            NotificationInfo notificationInfo = notificationInfoRepository
+                .findByMemberId(receiver.getId())
+                .orElseThrow(
+                    () -> new BudException(NOT_FOUND_NOTIFICATION_INFO));
+
+            //테스트를 위해 우선 주석처리 해두었음. 수신자와 송신자가 같으면 알람발생 x
+            //post 알람이 꺼져있는 수신자의 경우 알람발생 x
+//        if (!Objects.equals(receiver.getId(), member.getId())
+//            && notificationInfo.isPostPushAvailable()) {
+//            sendNotification(notificationInfo.getFcmToken(), receiver, member,
+//                post);
+//        }
+
+            if (notificationInfo.isPostPushAvailable()) {
+                fcmApi.sendNotificationByToken(
+                    NotificationDto.of(
+                        notificationInfo.getFcmToken()
+                        , receiver
+                        , member
+                        , NotificationType.FOLLOW
+                        , PageType.valueOf(post.getPostType().name())
+                        , post.getId()
+                        , NotificationDetailType.NEW_POST
+                    )
+                );
+            }
+        }
+    }
+
+    public void sendCreateQnaAnswerNotification(Member member, Post post) {
+        Member receiver = post.getMember();
+
+        NotificationInfo notificationInfo = notificationInfoRepository
+            .findByMemberId(receiver.getId())
+            .orElseThrow(() -> new BudException(NOT_FOUND_NOTIFICATION_INFO));
+
+        //테스트를 위해 우선 주석처리 해두었음. 수신자와 송신자가 같으면 알람발생 x
+        //post 알람이 꺼져있는 수신자의 경우 알람발생 x
+//        if (!Objects.equals(receiver.getId(), member.getId())
+//            && notificationInfo.isPostPushAvailable()) {
+//            sendNotification(notificationInfo.getFcmToken(), receiver, member,
+//                post);
+//        }
+
+        if (notificationInfo.isPostPushAvailable()) {
+            fcmApi.sendNotificationByToken(
+                NotificationDto.of(
+                    notificationInfo.getFcmToken()
+                    , receiver
+                    , member
+                    , NotificationType.POST
+                    , PageType.QNA
+                    , post.getId()
+                    , NotificationDetailType.ANSWER
+                )
+            );
+        }
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/post/service/PostService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/PostService.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.Order;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import zerobase.bud.awsS3.AwsS3Api;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.service.SendNotificationService;
 import zerobase.bud.post.domain.Image;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.PostLike;
@@ -30,8 +32,6 @@ import zerobase.bud.post.repository.PostRepository;
 import zerobase.bud.post.repository.PostRepositoryQuerydslImpl;
 import zerobase.bud.post.type.PostSortType;
 import zerobase.bud.post.type.PostStatus;
-
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,6 +48,9 @@ public class PostService {
 
     private final AwsS3Api awsS3Api;
 
+    private final SendNotificationService sendNotificationService;
+
+
     @Transactional
     public String createPost(Member member, List<MultipartFile> images,
         Request request) {
@@ -55,6 +58,8 @@ public class PostService {
         Post post = postRepository.save(Post.of(member, request));
 
         saveImageWithPost(images, post);
+
+        sendNotificationService.sendCreatePostNotification(member, post);
 
         return request.getTitle();
     }

--- a/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
@@ -4,13 +4,9 @@ import static zerobase.bud.common.type.ErrorCode.CHANGE_IMPOSSIBLE_PINNED_ANSWER
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_STATUS;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_TYPE_FOR_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.INVALID_QNA_ANSWER_STATUS;
-import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_QNA_ANSWER;
-import static zerobase.bud.common.type.ErrorCode.NOT_REGISTERED_MEMBER;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,14 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
-import zerobase.bud.fcm.FcmApi;
-import zerobase.bud.notification.domain.NotificationInfo;
-import zerobase.bud.notification.dto.NotificationDto;
-import zerobase.bud.notification.repository.NotificationInfoRepository;
-import zerobase.bud.notification.type.NotificationDetailType;
-import zerobase.bud.notification.type.NotificationStatus;
-import zerobase.bud.notification.type.NotificationType;
-import zerobase.bud.notification.type.PageType;
+import zerobase.bud.notification.service.SendNotificationService;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.dto.CreateQnaAnswer.Request;
@@ -36,16 +25,11 @@ import zerobase.bud.post.repository.QnaAnswerRepository;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
 import zerobase.bud.post.type.QnaAnswerStatus;
-import zerobase.bud.repository.MemberRepository;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class QnaAnswerService {
-
-    private final FcmApi fcmApi;
-
-    private final MemberRepository memberRepository;
 
     private final PostRepository postRepository;
 
@@ -53,7 +37,7 @@ public class QnaAnswerService {
 
     private final QnaAnswerPinRepository qnaAnswerPinRepository;
 
-    private final NotificationInfoRepository notificationInfoRepository;
+    private final SendNotificationService sendNotificationService;
 
     @Transactional
     public String createQnaAnswer(Member member, Request request) {
@@ -63,54 +47,14 @@ public class QnaAnswerService {
 
         validateCreateQnaAnswer(post);
 
-        qnaAnswerRepository.save(QnaAnswer.of(member, post, request.getContent()));
+        qnaAnswerRepository.save(
+            QnaAnswer.of(member, post, request.getContent()));
 
         post.plusCommentCount();
 
-        validateSendNotificationAndSend(member, post);
+        sendNotificationService.sendCreateQnaAnswerNotification(member, post);
 
         return member.getUserId();
-    }
-
-    private void validateSendNotificationAndSend(Member member, Post post) {
-        Long receiverId = post.getMember().getId();
-        NotificationInfo notificationInfo = notificationInfoRepository
-            .findByMemberId(receiverId)
-            .orElseThrow(() -> new BudException(NOT_FOUND_NOTIFICATION_INFO));
-
-        Member receiver = memberRepository.findById(receiverId)
-            .orElseThrow(() -> new BudException(NOT_REGISTERED_MEMBER));
-
-        //테스트를 위해 우선 주석처리 해두었음.
-//        if (!Objects.equals(receiver.getId(), member.getId())
-//            && notificationInfo.isPostPushAvailable()) {
-//            sendNotification(notificationInfo.getFcmToken(), receiver, member,
-//                post);
-//        }
-
-        if (notificationInfo.isPostPushAvailable()) {
-            sendNotification(notificationInfo.getFcmToken(), receiver, member,
-                post);
-        }
-    }
-
-    private void sendNotification(
-        String token
-        , Member receiver
-        , Member sender
-        , Post post
-    ) {
-        fcmApi.sendNotificationByToken(NotificationDto.builder()
-            .tokens(List.of(token))
-            .receiver(receiver)
-            .sender(sender)
-            .notificationType(NotificationType.POST)
-            .pageType(PageType.QNA)
-            .pageId(post.getId())
-            .notificationDetailType(NotificationDetailType.ANSWER)
-            .notificationStatus(NotificationStatus.UNREAD)
-            .notifiedAt(LocalDateTime.now())
-            .build());
     }
 
     @Transactional

--- a/user-api/src/test/java/zerobase/bud/fcm/FcmApiTest.java
+++ b/user-api/src/test/java/zerobase/bud/fcm/FcmApiTest.java
@@ -1,0 +1,123 @@
+package zerobase.bud.fcm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static zerobase.bud.notification.type.NotificationStatus.READ;
+import static zerobase.bud.notification.type.NotificationType.POST;
+import static zerobase.bud.notification.type.PageType.QNA;
+import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import zerobase.bud.domain.Member;
+import zerobase.bud.notification.dto.NotificationDto;
+import zerobase.bud.notification.repository.NotificationRepository;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+
+@SpringBootTest
+class FcmApiTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Value("${fcm.key.scope}")
+    private List<String> fireBaseScope;
+
+    @Value("${fcm.temp.token}")
+    private String fcmTempToken;
+
+    @InjectMocks
+    private FcmApi fcmApi;
+
+
+    @Test
+    void sendNotificationByToken()
+        throws FirebaseMessagingException, IOException {
+        String notificationId = makeNotificationId();
+        //given
+        NotificationDto notificationDto = NotificationDto.builder()
+            .tokens(List.of(fcmTempToken))
+            .receiver(getReceiver())
+            .sender(getSender())
+            .notificationType(POST)
+            .pageType(QNA)
+            .pageId(1L)
+            .notificationStatus(READ)
+            .notificationDetailType(NotificationDetailType.ANSWER)
+            .notifiedAt(LocalDateTime.now())
+            .build();
+
+        given(notificationRepository.save(any()))
+            .willReturn(zerobase.bud.notification.domain.Notification.builder()
+                .receiver(getReceiver())
+                .sender(getSender())
+                .notificationId(notificationId)
+                .notificationType(NotificationType.FOLLOW)
+                .pageType(PageType.FEED)
+                .pageId(1L)
+                .notificationStatus(NotificationStatus.UNREAD)
+                .notificationDetailType(NotificationDetailType.ANSWER)
+                .notifiedAt(LocalDateTime.now())
+                .build());
+
+        ArgumentCaptor<zerobase.bud.notification.domain.Notification>
+            captor = ArgumentCaptor.forClass(
+            zerobase.bud.notification.domain.Notification.class);
+
+        //when
+        // Set up mock Firebase SDK behavior
+        fcmApi.sendNotificationByToken(notificationDto);
+
+        //then
+        verify(notificationRepository, times(1)).save(captor.capture());
+        assertEquals("receiver", captor.getValue().getReceiver().getNickname());
+        assertEquals("sender", captor.getValue().getSender().getNickname());
+        assertEquals(POST, captor.getValue().getNotificationType());
+        assertEquals(QNA, captor.getValue().getPageType());
+        assertEquals(1L, captor.getValue().getPageId());
+        assertEquals(NotificationDetailType.ANSWER,
+            captor.getValue().getNotificationDetailType());
+        assertEquals(READ, captor.getValue().getNotificationStatus());
+    }
+
+    private static String makeNotificationId() {
+        return UUID.randomUUID().toString()
+            .replaceAll(REPLACE_EXPRESSION, "")
+            .concat(LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")));
+    }
+
+    private Member getReceiver() {
+        return Member.builder()
+            .id(1L)
+            .nickname("receiver")
+            .userId("receiver")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+
+    private Member getSender() {
+        return Member.builder()
+            .id(2L)
+            .nickname("sender")
+            .userId("sender")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+}

--- a/user-api/src/test/java/zerobase/bud/notification/service/SendNotificationServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/service/SendNotificationServiceTest.java
@@ -1,0 +1,176 @@
+package zerobase.bud.notification.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
+import static zerobase.bud.post.type.PostStatus.ACTIVE;
+import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zerobase.bud.common.exception.BudException;
+import zerobase.bud.domain.Member;
+import zerobase.bud.fcm.FcmApi;
+import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.domain.NotificationInfo;
+import zerobase.bud.notification.repository.NotificationInfoRepository;
+import zerobase.bud.notification.type.NotificationDetailType;
+import zerobase.bud.notification.type.NotificationStatus;
+import zerobase.bud.notification.type.NotificationType;
+import zerobase.bud.notification.type.PageType;
+import zerobase.bud.post.domain.Post;
+import zerobase.bud.post.type.PostType;
+import zerobase.bud.user.domain.Follow;
+import zerobase.bud.user.repository.FollowRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SendNotificationServiceTest {
+
+    @Mock
+    private NotificationInfoRepository notificationInfoRepository;
+
+    @Mock
+    private FcmApi fcmApi;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @InjectMocks
+    private SendNotificationService sendNotificationService;
+
+    @Test
+    void success_sendCreatePostNotification() {
+        //given
+        given(followRepository.findByTarget(any()))
+            .willReturn(Stream.of(getFollow()));
+
+        given(notificationInfoRepository.findByMemberId(anyLong()))
+            .willReturn(Optional.ofNullable(getNotificationInfo()));
+        //when
+        sendNotificationService.sendCreatePostNotification(
+            getSender(), getPost()
+        );
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND_NOTIFICATION_INFO_sendCreatePostNotification")
+    void NOT_FOUND_NOTIFICATION_INFO_sendCreatePostNotification() {
+        //given
+        given(followRepository.findByTarget(any()))
+            .willReturn(Stream.of(getFollow()));
+
+        given(notificationInfoRepository.findByMemberId(anyLong()))
+            .willReturn(Optional.empty());
+        //when
+        BudException budException = assertThrows(BudException.class,
+            () -> sendNotificationService.sendCreatePostNotification(
+                getSender(), getPost()
+            ));
+
+        assertEquals(NOT_FOUND_NOTIFICATION_INFO, budException.getErrorCode());
+    }
+
+    @Test
+    void success_sendCreateQnaAnswerNotification() {
+        //given
+        given(notificationInfoRepository.findByMemberId(anyLong()))
+            .willReturn(Optional.ofNullable(getNotificationInfo()));
+
+        //when
+        sendNotificationService.sendCreateQnaAnswerNotification(
+            getSender(), getPost()
+        );
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND_NOTIFICATION_INFO_sendCreateQnaAnswerNotification")
+    void NOT_FOUND_NOTIFICATION_INFO_sendCreateQnaAnswerNotification() {
+        //given
+        given(notificationInfoRepository.findByMemberId(anyLong()))
+            .willReturn(Optional.empty());
+        //when
+        BudException budException = assertThrows(BudException.class,
+            () -> sendNotificationService.sendCreateQnaAnswerNotification(
+                getSender(), getPost()
+            ));
+
+        assertEquals(NOT_FOUND_NOTIFICATION_INFO, budException.getErrorCode());
+    }
+
+    private Post getPost() {
+        return Post.builder()
+            .member(getSender())
+            .title("title")
+            .content("content")
+            .postStatus(ACTIVE)
+            .postType(PostType.FEED)
+            .build();
+    }
+
+    private String makeNotificationId() {
+        return UUID.randomUUID().toString()
+            .replaceAll(REPLACE_EXPRESSION, "")
+            .concat(LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")));
+    }
+
+    private NotificationInfo getNotificationInfo() {
+        return NotificationInfo.builder()
+            .fcmToken("fcmToken")
+            .isPostPushAvailable(true)
+            .isFollowPushAvailable(true)
+            .build();
+    }
+
+    private Notification getNotification(String notificationId) {
+        return Notification.builder()
+            .receiver(getReceiver())
+            .sender(getSender())
+            .notificationId(notificationId)
+            .notificationType(NotificationType.POST)
+            .pageType(PageType.QNA)
+            .pageId(1L)
+            .notificationDetailType(NotificationDetailType.ANSWER)
+            .notificationStatus(NotificationStatus.UNREAD)
+            .notifiedAt(LocalDateTime.now())
+            .build();
+    }
+
+    private Follow getFollow() {
+        return Follow.builder()
+            .member(getSender())
+            .target(getReceiver())
+            .id(2L)
+            .build();
+    }
+
+    private Member getReceiver() {
+        return Member.builder()
+            .id(1L)
+            .nickname("receiver")
+            .userId("receiver")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+
+    private Member getSender() {
+        return Member.builder()
+            .id(2L)
+            .nickname("sender")
+            .userId("sender")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+    }
+}

--- a/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
@@ -35,6 +35,7 @@ import zerobase.bud.awsS3.AwsS3Api;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Level;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.service.SendNotificationService;
 import zerobase.bud.post.domain.Image;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.PostLike;
@@ -66,6 +67,9 @@ class PostServiceTest {
 
     @Mock
     private AwsS3Api awsS3Api;
+
+    @Mock
+    private SendNotificationService sendNotificationService;
 
     @InjectMocks
     private PostService postService;

--- a/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
@@ -11,10 +11,8 @@ import static zerobase.bud.common.type.ErrorCode.CHANGE_IMPOSSIBLE_PINNED_ANSWER
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_STATUS;
 import static zerobase.bud.common.type.ErrorCode.INVALID_POST_TYPE_FOR_ANSWER;
 import static zerobase.bud.common.type.ErrorCode.INVALID_QNA_ANSWER_STATUS;
-import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_POST;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_QNA_ANSWER;
-import static zerobase.bud.common.type.ErrorCode.NOT_REGISTERED_MEMBER;
 import static zerobase.bud.post.type.PostStatus.ACTIVE;
 import static zerobase.bud.post.type.PostStatus.INACTIVE;
 
@@ -29,9 +27,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
-import zerobase.bud.fcm.FcmApi;
 import zerobase.bud.notification.domain.NotificationInfo;
-import zerobase.bud.notification.repository.NotificationInfoRepository;
+import zerobase.bud.notification.service.SendNotificationService;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.domain.QnaAnswerPin;
@@ -42,7 +39,6 @@ import zerobase.bud.post.repository.QnaAnswerPinRepository;
 import zerobase.bud.post.repository.QnaAnswerRepository;
 import zerobase.bud.post.type.PostType;
 import zerobase.bud.post.type.QnaAnswerStatus;
-import zerobase.bud.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
 class QnaAnswerServiceTest {
@@ -57,13 +53,7 @@ class QnaAnswerServiceTest {
     private QnaAnswerPinRepository qnaAnswerPinRepository;
 
     @Mock
-    private NotificationInfoRepository notificationInfoRepository;
-
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
-    private FcmApi fcmApi;
+    private SendNotificationService sendNotificationService;
 
     @InjectMocks
     private QnaAnswerService qnaAnswerService;
@@ -77,12 +67,6 @@ class QnaAnswerServiceTest {
 
         given(qnaAnswerRepository.save(any()))
             .willReturn(getQnaAnswer());
-
-        given(notificationInfoRepository.findByMemberId(getSender().getId()))
-            .willReturn(Optional.ofNullable(getNotificationInfo()));
-
-        given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.ofNullable(getReceiver()));
 
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(
             QnaAnswer.class);
@@ -182,61 +166,6 @@ class QnaAnswerServiceTest {
                     .build()));
         //then 이런 결과가 나온다.
         assertEquals(INVALID_POST_STATUS, budException.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("NOT_FOUND_NOTIFICATION_INFO_createQnaAnswer")
-    void NOT_FOUND_NOTIFICATION_INFO_createQnaAnswer() {
-        //given
-
-        given(postRepository.findById(anyLong()))
-            .willReturn(Optional.ofNullable(getPost()));
-
-        given(qnaAnswerRepository.save(any()))
-            .willReturn(getQnaAnswer());
-
-        given(notificationInfoRepository.findByMemberId(getSender().getId()))
-            .willReturn(Optional.empty());
-
-        //when 어떤 경우에
-        BudException budException = assertThrows(BudException.class,
-            () -> qnaAnswerService.createQnaAnswer(getSender(),
-                Request.builder()
-                    .postId(1L)
-                    .content("content")
-                    .build()));
-        //then 이런 결과가 나온다.
-        assertEquals(NOT_FOUND_NOTIFICATION_INFO, budException.getErrorCode());
-
-    }
-
-    @Test
-    @DisplayName("NOT_REGISTERED_MEMBER_createQnaAnswer")
-    void NOT_REGISTERED_MEMBER_createQnaAnswer() {
-        //given
-
-        given(postRepository.findById(anyLong()))
-            .willReturn(Optional.ofNullable(getPost()));
-
-        given(qnaAnswerRepository.save(any()))
-            .willReturn(getQnaAnswer());
-
-        given(notificationInfoRepository.findByMemberId(getSender().getId()))
-            .willReturn(Optional.ofNullable(getNotificationInfo()));
-
-        given(memberRepository.findById(anyLong()))
-            .willReturn(Optional.empty());
-
-        //when 어떤 경우에
-        BudException budException = assertThrows(BudException.class,
-            () -> qnaAnswerService.createQnaAnswer(getSender(),
-                Request.builder()
-                    .postId(1L)
-                    .content("content")
-                    .build()));
-        //then 이런 결과가 나온다.
-        assertEquals(NOT_REGISTERED_MEMBER, budException.getErrorCode());
-
     }
 
     @Test


### PR DESCRIPTION


## 작업 내용 (Content)
- 변경 사항 1
   - 기존에 yml파일을 통해 fcmTmpToken으로 받던 것을 알림 정보에 저장된 token을 가져오는 것으로 로직 수정 
- 변경 사항 2
   - SendNotificationService로 알림 송신하는 서비스를 분리
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 18. Tue`
