### PR TITLE
[Feat-PinQnaAnswer] QnA 답변을 핀하고 핀 삭제하는 기능 구현

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -633,7 +633,43 @@ include::{snippets}/qna-answer-controller-test/success-delete-comment/http-respo
 |400|NOT_COMMENT_OWNER|댓글의 작성자가 아닙니다.
 |===
 
+=== 20. Q&A 답변 핀 기능
+.request
+include::{snippets}/qna-answer-controller-test/success_qna-answer-pin/http-request.adoc[]
 
+.request field
+|===
+|필드명|타입|필수여부|설명
+|qnaAnswerId|Number|Y|path variable, QnA답글의 Id
+|===
+
+.response
+include::{snippets}/qna-answer-controller-test/success_qna-answer-pin/http-response.adoc[]
+
+.response field
+|===
+|필드명|타입|필수여부|설명
+|qnaAnswerId|Number|Y|path variable, QnA답글의 Id
+|===
+
+=== 21. Q&A 답변 핀 취소
+.request
+include::{snippets}/qna-answer-controller-test/success_cancel-qna-answer-pin/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|qnaAnswerPinId|Number|Y|path variable, QnA답글 핀의 Id
+|===
+
+.response
+include::{snippets}/qna-answer-controller-test/success_cancel-qna-answer-pin/http-response.adoc[]
+
+.response field
+|===
+|필드명|타입|필수여부|설명
+|qnaAnswerPinId|Number|Y|path variable, QnA답글 핀의 Id
+|===
 
 == 유저 API
 === 1. 유저 팔로우 / 팔로우 취소

--- a/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
+++ b/user-api/src/main/java/zerobase/bud/common/type/ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    NOT_FOUND_QNA_ANSWER_PIN("존재하지 않는 QnA 답변 핀입니다."),
     NOT_RECEIVED_NOTIFICATION_MEMBER("알림을 수신한 회원이 아닙니다."),
     NOT_FOUND_NOTIFICATION("존재하지 않는 알림입니다."),
     NOT_FOUND_NOTIFICATION_INFO("알림 정보가 없습니다."),

--- a/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
@@ -56,11 +56,7 @@ public class PostController {
             @RequestPart(value = IMAGES, required = false) List<MultipartFile> images,
             @RequestPart(value = UPDATE_POST_REQUEST) @Valid UpdatePost.Request request
     ) {
-        return ResponseEntity.ok(postService.updatePost(
-                        images
-                        , request
-                )
-        );
+        return ResponseEntity.ok(postService.updatePost(images, request));
     }
 
     @GetMapping

--- a/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
@@ -16,7 +16,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts/qna-answer")
+@RequestMapping("/posts/qna-answers")
 public class QnaAnswerController {
 
     private final QnaAnswerService qnaAnswerService;
@@ -73,5 +73,21 @@ public class QnaAnswerController {
     public ResponseEntity<Long> deleteComment(@PathVariable Long qnaCommentId,
                                               @AuthenticationPrincipal Member member) {
         return ResponseEntity.ok(qnaAnswerCommentService.delete(qnaCommentId, member));
+    }
+
+    @PostMapping("/{qnaAnswerId}/pin")
+    public ResponseEntity<Long> qnaAnswerPin(
+        @PathVariable Long qnaAnswerId,
+        @AuthenticationPrincipal Member member
+    ){
+        return ResponseEntity.ok(qnaAnswerService.qnaAnswerPin(qnaAnswerId, member));
+    }
+
+    @DeleteMapping("/pin/{qnaAnswerPinId}")
+    public ResponseEntity<Long> cancelQnaAnswerPin(
+        @PathVariable Long qnaAnswerPinId,
+        @AuthenticationPrincipal Member member
+    ) {
+        return ResponseEntity.ok(qnaAnswerService.cancelQnaAnswerPin(qnaAnswerPinId, member));
     }
 }

--- a/user-api/src/main/java/zerobase/bud/post/domain/Post.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/Post.java
@@ -51,6 +51,9 @@ public class Post extends BaseEntity {
     @OneToOne(mappedBy = "post")
     private CommentPin commentPin;
 
+    @OneToOne(mappedBy = "post")
+    private QnaAnswerPin qnaAnswerPin;
+
     public static Post of(Member member, CreatePost.Request request){
         return Post.builder()
                 .member(member)

--- a/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswerPin.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswerPin.java
@@ -4,7 +4,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,10 +25,17 @@ public class QnaAnswerPin extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
     private Post post;
 
-    @ManyToOne
+    @OneToOne
     private QnaAnswer qnaAnswer;
 
+    public static QnaAnswerPin of(QnaAnswer qnaAnswer, Post post) {
+        return QnaAnswerPin.builder()
+            .post(post)
+            .qnaAnswer(qnaAnswer)
+            .build();
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerPinRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerPinRepository.java
@@ -10,4 +10,7 @@ public interface QnaAnswerPinRepository extends
     JpaRepository<QnaAnswerPin, Long> {
 
     Optional<QnaAnswerPin> findByQnaAnswerId(Long qnaAnswerId);
+
+    void deleteByPostId(Long postId);
+
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
@@ -1,13 +1,13 @@
 package zerobase.bud.post.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.type.QnaAnswerStatus;
 
-import java.util.Optional;
-
 @Repository
 public interface QnaAnswerRepository extends JpaRepository<QnaAnswer, Long> {
     Optional<QnaAnswer> findByIdAndQnaAnswerStatus(Long id, QnaAnswerStatus qnaAnswerStatus);
+
 }

--- a/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
@@ -1,6 +1,28 @@
 package zerobase.bud.post.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,21 +50,6 @@ import zerobase.bud.post.dto.CreateQnaAnswer;
 import zerobase.bud.post.dto.QnaAnswerCommentDto;
 import zerobase.bud.post.dto.UpdateQnaAnswer;
 import zerobase.bud.post.service.QnaAnswerService;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith({RestDocumentationExtension.class})
 @WebMvcTest(QnaAnswerController.class)
@@ -95,7 +102,7 @@ class QnaAnswerControllerTest {
 
         //when
         //then
-        mockMvc.perform(post("/posts/qna-answer")
+        mockMvc.perform(post("/posts/qna-answers")
                         .header("Authorization", TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
@@ -122,7 +129,7 @@ class QnaAnswerControllerTest {
 
         //when
         //then
-        mockMvc.perform(put("/posts/qna-answer")
+        mockMvc.perform(put("/posts/qna-answers")
                         .header("Authorization", TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
@@ -149,7 +156,7 @@ class QnaAnswerControllerTest {
                 .willReturn(1L);
         //when
         //then
-        this.mockMvc.perform(RestDocumentationRequestBuilders.post("/posts/qna-answer/qna-comments/{qnaCommentId}/like", 1)
+        this.mockMvc.perform(RestDocumentationRequestBuilders.post("/posts/qna-answers/qna-comments/{qnaCommentId}/like", 1)
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -172,7 +179,7 @@ class QnaAnswerControllerTest {
                 .willReturn(1L);
         //when
         //then
-        this.mockMvc.perform(RestDocumentationRequestBuilders.post("/posts/qna-answer/qna-comments/{qnaCommentId}/pin", 1)
+        this.mockMvc.perform(RestDocumentationRequestBuilders.post("/posts/qna-answers/qna-comments/{qnaCommentId}/pin", 1)
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -194,7 +201,7 @@ class QnaAnswerControllerTest {
                 .willReturn(1L);
         //when
         //then
-        this.mockMvc.perform(delete("/posts/qna-answer/{qnaAnswerId}/qna-comments/pin", 1)
+        this.mockMvc.perform(delete("/posts/qna-answers/{qnaAnswerId}/qna-comments/pin", 1)
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -293,7 +300,7 @@ class QnaAnswerControllerTest {
                 .willReturn(new SliceImpl<>(dtos));
 
 
-        this.mockMvc.perform(get("/posts/qna-answer/{qnaAnswerId}/qna-comments", 1)
+        this.mockMvc.perform(get("/posts/qna-answers/{qnaAnswerId}/qna-comments", 1)
                         .param("page", "0")
                         .param("size", "5")
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)
@@ -350,7 +357,7 @@ class QnaAnswerControllerTest {
                 .willReturn(2L);
         //when
         //then
-        this.mockMvc.perform(delete("/posts/qna-answer/qna-comments/{qnaCommentId}", 1)
+        this.mockMvc.perform(delete("/posts/qna-answers/qna-comments/{qnaCommentId}", 1)
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -361,5 +368,51 @@ class QnaAnswerControllerTest {
                                 preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
                                 preprocessResponse(prettyPrint()))
                 );
+    }
+
+    @Test
+    @WithMockUser
+    void success_qnaAnswerPin() throws Exception {
+        //given
+        given(qnaAnswerService.qnaAnswerPin(anyLong(), any()))
+            .willReturn(3L);
+
+        //when
+        //then
+        mockMvc.perform(post("/posts/qna-answers/3/pin")
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").value(3))
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
+    }
+
+    @Test
+    @WithMockUser
+    void success_cancelQnaAnswerPin() throws Exception {
+        //given
+        given(qnaAnswerService.cancelQnaAnswerPin(anyLong(), any()))
+            .willReturn(1L);
+
+        //when
+        //then
+        mockMvc.perform(delete("/posts/qna-answers/pin/1")
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").value(1))
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - QnA 답변 핀 , Qna 답변 핀 취소(삭제) 기능 구현
- 변경 사항 2
   - RESTApi url 변경 :  /posts/qna-answer =>  /posts/qna-answers 로 변경하였습니다.
- 변경 사항 3
   - 테스트 코드 구현
   
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 18. Tue`
