### PR TITLE
refactor : [Refactor-SaveNotificationInfo] 기존 로직 변경

### DIFF
--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationInfoService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationInfoService.java
@@ -2,6 +2,7 @@ package zerobase.bud.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import zerobase.bud.domain.Member;
 import zerobase.bud.notification.domain.NotificationInfo;
 import zerobase.bud.notification.dto.SaveNotificationInfo;
@@ -13,8 +14,14 @@ public class NotificationInfoService {
 
     private final NotificationInfoRepository notificationInfoRepository;
 
+    @Transactional
     public String saveNotificationInfo(SaveNotificationInfo.Request request, Member member) {
-        notificationInfoRepository.save(NotificationInfo.of(request, member));
+
+        notificationInfoRepository.findByMemberId(member.getId())
+                .ifPresentOrElse(
+                    notificationInfo -> notificationInfo.setFcmToken(request.getFcmToken()),
+                    () -> notificationInfoRepository.save(NotificationInfo.of(request, member)));
+
         return request.getFcmToken();
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 
   - 토큰 및 알림 정보들을 저장하는 로직의 변경
     기존엔 알림 동의 여부까지 모두 저장했는데 지금부터는 처음 저장 시에만 알림 정보 저장하고 그 이후 로그인부터는 
     fcmToken만 update하는 것으로 로직 변경

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 19. Wed`
