### PR TITLE
마이페이지 게시글 조회 기능 추가 및 게시글 응답 데이터에 좋아요, 스크랩 유무, 게시글 작성자 팔로우 유무 확인 데이터 추가

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -300,6 +300,7 @@ include::{snippets}/post-controller-test/success_search-posts/http-request.adoc[
 |order|String|N|정렬기준(ASC or DESC)|DESC
 |page|Number|N|요청 페이지 번호|0
 |size|Number|N|요청 데이터 개수|10
+|postType|String|N|요청 페이지 종류(FEED, QNA) 이며, null 이라면, FEED, QNA 전체를 보내줍니다. |null
 |===
 
 .response
@@ -874,6 +875,36 @@ include::{snippets}/user-controller-test/success-delete-scrap/http-request.adoc[
 
 .response
 include::{snippets}/user-controller-test/success-delete-scrap/http-response.adoc[]
+
+=== 10. 마이페이지 게시글 리스트 조회
+.request
+include::{snippets}/user-controller-test/success-search-my-page-posts/http-request.adoc[]
+
+.request example
+|===
+|url|예시
+|/users/{my-page-userId}/posts|/users/2/posts
+|===
+
+.request field
+|===
+|필드명|타입|필수여부|설명|기본값
+|size|Number|N|요청 데이터 개수|5
+|page|Number|N|요청 페이지 번호|0
+|sort|String|N|정렬기준(
+(DATE,DESC(ASC)), (HIT,DESC(ASC)), (LIKE,DESC(ASC))
+)|DATE,DESC
+|===
+
+.response
+include::{snippets}/user-controller-test/success-search-my-page-posts/http-response.adoc[]
+
+.response
+include::{snippets}/user-controller-test/success-search-my-page-posts/http-response.adoc[]
+
+
+
+
 
 == 알림 API
 === 1. 알림 조회

--- a/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
@@ -10,13 +10,11 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import zerobase.bud.comment.service.CommentService;
 import zerobase.bud.domain.Member;
-import zerobase.bud.post.dto.CommentDto;
-import zerobase.bud.post.dto.CreatePost;
-import zerobase.bud.post.dto.PostDto;
-import zerobase.bud.post.dto.UpdatePost;
+import zerobase.bud.post.dto.*;
 import zerobase.bud.post.service.PostService;
 import zerobase.bud.post.service.ScrapService;
 import zerobase.bud.post.type.PostSortType;
+import zerobase.bud.post.type.PostType;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -60,20 +58,26 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<PostDto>> searchPosts(
+    public ResponseEntity<Page<SearchPost.Response>> searchPosts(
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false, defaultValue = "DATE") PostSortType sort,
             @RequestParam(required = false, defaultValue = "DESC") Order order,
             @RequestParam(required = false, defaultValue = "0") int page,
-            @RequestParam(required = false, defaultValue = "10") int size
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false) PostType postType,
+            @AuthenticationPrincipal Member member
     ) {
         return ResponseEntity.ok(
-                postService.searchPosts(keyword, sort, order, page, size));
+                postService.searchPosts(member, keyword, sort, order,
+                        page, size, postType));
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDto> searchPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.searchPost(postId));
+    public ResponseEntity<SearchPost.Response> searchPost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal Member member
+    ) {
+        return ResponseEntity.ok(postService.searchPost(member, postId));
     }
 
     @DeleteMapping("/{postId}")

--- a/user-api/src/main/java/zerobase/bud/post/dto/PostDto.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/PostDto.java
@@ -1,27 +1,27 @@
 package zerobase.bud.post.dto;
 
-import lombok.*;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import zerobase.bud.domain.Member;
-import zerobase.bud.post.domain.Image;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@NoArgsConstructor
 public class PostDto {
     private long id;
 
     private Member member;
 
     private String title;
-    private String[] imageUrls;
     private String content;
 
     private long commentCount;
@@ -35,18 +35,43 @@ public class PostDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static PostDto fromEntity(Post post, List<Image> images) {
-        String[] imageUrls = new String[images.size()];
+    private boolean isLike;
+    private boolean isScrap;
+    private boolean isFollow;
 
-        for (int i = 0; i < images.size(); i++) {
-            imageUrls[i] = images.get(i).getImagePath();
-        }
+    @QueryProjection
+    public PostDto(long id, Member member, String title, String content,
+                   long commentCount, long likeCount, long scrapCount,
+                   long hitCount, PostStatus postStatus, PostType postType,
+                   LocalDateTime createdAt, LocalDateTime updatedAt,
+                   boolean isLike, boolean isScrap, boolean isFollow) {
+        this.id = id;
+        this.member = member;
+        this.title = title;
+        this.content = content;
+        this.commentCount = commentCount;
+        this.likeCount = likeCount;
+        this.scrapCount = scrapCount;
+        this.hitCount = hitCount;
+        this.postStatus = postStatus;
+        this.postType = postType;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isLike = isLike;
+        this.isScrap = isScrap;
+        this.isFollow = isFollow;
+    }
 
+
+
+
+
+
+    public static PostDto of(Post post) {
         return PostDto.builder()
                 .id(post.getId())
                 .member(post.getMember())
                 .title(post.getTitle())
-                .imageUrls(imageUrls)
                 .content(post.getContent())
                 .commentCount(post.getCommentCount())
                 .likeCount(post.getLikeCount())

--- a/user-api/src/main/java/zerobase/bud/post/dto/ScrapDto.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/ScrapDto.java
@@ -14,13 +14,13 @@ import java.util.List;
 @Builder
 public class ScrapDto {
     private Long id;
-    private PostDto post;
+    private SearchPost.Response post;
     private LocalDateTime createdAt;
 
-    public static ScrapDto fromScrapWithImages(Scrap scrap, List<Image> images) {
+    public static ScrapDto of(Scrap scrap, List<Image> images) {
         return ScrapDto.builder()
                 .id(scrap.getId())
-                .post(PostDto.fromEntity(scrap.getPost(), images))
+                .post(SearchPost.Response.of(PostDto.of(scrap.getPost()), images))
                 .createdAt(scrap.getCreatedAt())
                 .build();
     }

--- a/user-api/src/main/java/zerobase/bud/post/dto/SearchMyPagePost.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/SearchMyPagePost.java
@@ -1,0 +1,72 @@
+package zerobase.bud.post.dto;
+
+import lombok.*;
+import zerobase.bud.post.domain.Image;
+import zerobase.bud.post.type.PostStatus;
+import zerobase.bud.post.type.PostType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SearchMyPagePost {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private long postId;
+
+        private String title;
+
+        private long postRegisterMemberId;
+
+        private String[] imageUrls;
+
+        private String content;
+
+        private long commentCount;
+
+        private long likeCount;
+        private long scrapCount;
+        private long hitCount;
+
+        private boolean isLike;
+        private boolean isScrap;
+        private boolean isFollow;
+
+        private PostStatus postStatus;
+        private PostType postType;
+
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Response of(PostDto post, List<Image> images) {
+            String[] imageUrls = new String[images.size()];
+
+            for (int i = 0; i < images.size(); i++) {
+                imageUrls[i] = images.get(i).getImagePath();
+            }
+
+            return Response.builder()
+                    .postId(post.getId())
+                    .title(post.getTitle())
+                    .postRegisterMemberId(post.getMember().getId())
+                    .imageUrls(imageUrls)
+                    .content(post.getContent())
+                    .commentCount(post.getCommentCount())
+                    .likeCount(post.getLikeCount())
+                    .scrapCount(post.getScrapCount())
+                    .hitCount(post.getHitCount())
+                    .postStatus(post.getPostStatus())
+                    .postType(post.getPostType())
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .isLike(post.isLike())
+                    .isScrap(post.isScrap())
+                    .isFollow(post.isFollow())
+                    .build();
+        }
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/post/dto/SearchPost.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/SearchPost.java
@@ -1,0 +1,72 @@
+package zerobase.bud.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zerobase.bud.domain.Member;
+import zerobase.bud.post.domain.Image;
+import zerobase.bud.post.type.PostStatus;
+import zerobase.bud.post.type.PostType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SearchPost {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private long id;
+
+        private Member member;
+
+        private String title;
+        private String[] imageUrls;
+        private String content;
+
+        private long commentCount;
+        private long likeCount;
+        private long scrapCount;
+        private long hitCount;
+
+        private boolean isLike;
+        private boolean isScrap;
+        private boolean isFollow;
+
+        private PostStatus postStatus;
+        private PostType postType;
+
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Response of(PostDto post, List<Image> images) {
+            String[] imageUrls = new String[images.size()];
+
+            for (int i = 0; i < images.size(); i++) {
+                imageUrls[i] = images.get(i).getImagePath();
+            }
+
+            return Response.builder()
+                    .id(post.getId())
+                    .member(post.getMember())
+                    .title(post.getTitle())
+                    .imageUrls(imageUrls)
+                    .content(post.getContent())
+                    .commentCount(post.getCommentCount())
+                    .likeCount(post.getLikeCount())
+                    .scrapCount(post.getScrapCount())
+                    .hitCount(post.getHitCount())
+                    .postStatus(post.getPostStatus())
+                    .postType(post.getPostType())
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .isLike(post.isLike())
+                    .isScrap(post.isScrap())
+                    .isFollow(post.isFollow())
+                    .build();
+        }
+    }
+}

--- a/user-api/src/main/java/zerobase/bud/post/repository/PostRepositoryQuerydsl.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/PostRepositoryQuerydsl.java
@@ -4,12 +4,21 @@ package zerobase.bud.post.repository;
 import com.querydsl.core.types.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import zerobase.bud.post.domain.Post;
+import zerobase.bud.post.dto.PostDto;
 import zerobase.bud.post.type.PostSortType;
+import zerobase.bud.post.type.PostType;
+
+import java.util.Optional;
 
 public interface PostRepositoryQuerydsl {
-    Page<Post> findAllByPostStatus(String keyword,
-                                   PostSortType sortType,
-                                   Order order,
-                                   Pageable pageable);
+    Page<PostDto> findAllByPostStatus(Long memberId,
+                                      String keyword,
+                                      PostSortType sortType,
+                                      Order order,
+                                      Pageable pageable,
+                                      PostType pageType);
+
+    Page<PostDto> findAllByMyPagePost(Long memberId, Long myPageUserId, Pageable pageable);
+
+    Optional<PostDto> findByPostId(Long memberId, Long postId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/PostRepositoryQuerydslImpl.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/PostRepositoryQuerydslImpl.java
@@ -1,22 +1,34 @@
 package zerobase.bud.post.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
-import zerobase.bud.post.domain.Post;
+import zerobase.bud.post.dto.PostDto;
+import zerobase.bud.post.dto.QPostDto;
 import zerobase.bud.post.type.PostSortType;
+import zerobase.bud.post.type.PostType;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static zerobase.bud.post.domain.QPost.post;
+import static zerobase.bud.post.domain.QPostLike.postLike;
+import static zerobase.bud.post.domain.QScrap.scrap;
 import static zerobase.bud.post.type.PostStatus.ACTIVE;
+import static zerobase.bud.post.type.PostStatus.INACTIVE;
+import static zerobase.bud.user.domain.QFollow.follow;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,20 +37,79 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<Post> findAllByPostStatus(String keyword, PostSortType sortType,
-                                          Order order, Pageable pageable) {
+    public Page<PostDto> findAllByPostStatus(Long memberId,
+                                             String keyword,
+                                             PostSortType sortType,
+                                             Order order,
+                                             Pageable pageable,
+                                             PostType postType) {
         return new PageImpl<>(
-                searchPosts(keyword, sortType, order, pageable),
+                searchPosts(memberId, keyword, sortType, order, pageable, postType),
                 pageable,
                 searchPostsCount(keyword)
         );
     }
 
-    private List<Post> searchPosts(String keyword, PostSortType sortType,
-                                Order order, Pageable pageable) {
+    @Override
+    public Page<PostDto> findAllByMyPagePost(Long memberId, Long myPageUserId, Pageable pageable) {
+        return new PageImpl<>(
+                searchMyPagePosts(memberId, myPageUserId, pageable),
+                pageable,
+                countMyPagePosts(memberId)
+        );
+    }
+
+    @Override
+    public Optional<PostDto> findByPostId(Long memberId, Long postId) {
+        return Optional.ofNullable(jpaQueryFactory
+                .select(new QPostDto(
+                        post.id,
+                        post.member,
+                        post.title,
+                        post.content,
+                        post.commentCount,
+                        post.likeCount,
+                        post.scrapCount,
+                        post.hitCount,
+                        post.postStatus,
+                        post.postType,
+                        post.createdAt,
+                        post.updatedAt,
+                        isUserPostLike(memberId),
+                        isUserPostScrap(memberId),
+                        isUserPostRegisterUserFollow(memberId)
+                ))
+                .from(post)
+                .where(post.id.eq(postId), eqStatus())
+                .fetchOne());
+    }
+
+    private List<PostDto> searchPosts(Long memberId,
+                                      String keyword,
+                                      PostSortType sortType,
+                                      Order order,
+                                      Pageable pageable,
+                                      PostType postType) {
         return jpaQueryFactory
-                .selectFrom(post)
-                .where(search(keyword), eqStatus())
+                .select(new QPostDto(
+                        post.id,
+                        post.member,
+                        post.title,
+                        post.content,
+                        post.commentCount,
+                        post.likeCount,
+                        post.scrapCount,
+                        post.hitCount,
+                        post.postStatus,
+                        post.postType,
+                        post.createdAt,
+                        post.updatedAt,
+                        isUserPostLike(memberId),
+                        isUserPostScrap(memberId),
+                        isUserPostRegisterUserFollow(memberId)
+                ))
+                .from(post)
+                .where(search(keyword), eqStatus(), eqType(postType))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(sortPostsList(sortType, order))
@@ -53,19 +124,124 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                 .fetchOne();
     }
 
+    private List<PostDto> searchMyPagePosts(Long memberId, Long myPageUserId, Pageable pageable) {
+        List<OrderSpecifier<?>> orders = getOrders(pageable);
+
+        return jpaQueryFactory
+                .select(new QPostDto(
+                        post.id,
+                        post.member,
+                        post.title,
+                        post.content,
+                        post.commentCount,
+                        post.likeCount,
+                        post.scrapCount,
+                        post.hitCount,
+                        post.postStatus,
+                        post.postType,
+                        post.createdAt,
+                        post.updatedAt,
+                        isUserPostLike(memberId),
+                        isUserPostScrap(memberId),
+                        isUserPostRegisterUserFollow(memberId)
+                ))
+                .from(post)
+                .where(neStatus(), eqPostRegisterMemberId(myPageUserId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(orders.toArray(OrderSpecifier[]::new))
+                .fetch();
+    }
+
+    private Expression<Boolean> isUserPostLike(Long memberId) {
+        return ExpressionUtils.as(
+                JPAExpressions.select(postLike.count()
+                                .when(0L)
+                                .then(false)
+                                .otherwise(true)
+                        )
+                        .from(postLike)
+                        .where(postLike.post.id.eq(post.id),
+                                postLike.member.id.eq(memberId)), "isLike");
+
+    }
+
+    private Expression<Boolean> isUserPostScrap(Long memberId) {
+        return ExpressionUtils.as(
+                JPAExpressions.select(scrap.count()
+                                .when(0L)
+                                .then(false)
+                                .otherwise(true)
+                        )
+                        .from(scrap)
+                        .where(scrap.post.id.eq(post.id),
+                                scrap.member.id.eq(memberId)), "isScrap");
+
+    }
+
+    private Expression<Boolean> isUserPostRegisterUserFollow(Long memberId) {
+        return ExpressionUtils.as(
+                JPAExpressions.select(follow.count()
+                                .when(0L)
+                                .then(false)
+                                .otherwise(true)
+                        )
+                        .from(follow)
+                        .where(follow.target.id.eq(post.member.id),
+                                follow.member.id.eq(memberId)), "isFollow");
+
+    }
+
+    private Long countMyPagePosts(Long memberId) {
+        return jpaQueryFactory
+                .select(post.count())
+                .from(post)
+                .where(neStatus(), eqPostRegisterMemberId(memberId))
+                .fetchOne();
+    }
+
     private BooleanBuilder search(String keyword) {
         return keyword == null ? null :
                 new BooleanBuilder()
                         .or(post.content.contains(keyword))
                         .or(post.title.contains(keyword))
-                        ;
+                ;
     }
 
     private BooleanExpression eqStatus() {
         return post.postStatus.eq(ACTIVE);
     }
 
-    private OrderSpecifier<?> sortPostsList(PostSortType sortType, Order order) {
+    private BooleanExpression eqType(PostType type) {
+        return type == null ? null : post.postType.eq(type);
+    }
+
+    private BooleanExpression neStatus() {
+        return post.postStatus.ne(INACTIVE);
+    }
+
+    private BooleanExpression eqPostRegisterMemberId(Long memberId) {
+        return post.member.id.eq(memberId);
+    }
+
+    private List<OrderSpecifier<?>> getOrders(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction =
+                    order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+            PostSortType postSortType =
+                    PostSortType.valueOf(order.getProperty());
+
+            orders.add(sortPostsList(postSortType, direction));
+        }
+
+        return orders;
+    }
+
+    private OrderSpecifier<?> sortPostsList(PostSortType sortType,
+                                            Order order) {
         switch (sortType) {
             case HIT:
                 return new OrderSpecifier<>(order, post.hitCount);

--- a/user-api/src/main/java/zerobase/bud/post/service/ScrapService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/ScrapService.java
@@ -66,7 +66,7 @@ public class ScrapService {
 
         return new SliceImpl<>(
                 scraps.stream()
-                        .map(scrap -> ScrapDto.fromScrapWithImages(scrap,
+                        .map(scrap -> ScrapDto.of(scrap,
                                 imageRepository.findAllByPostId(scrap.getPost().getId())))
                         .collect(Collectors.toList()),
                 scraps.getPageable(),

--- a/user-api/src/main/java/zerobase/bud/user/controller/UserController.java
+++ b/user-api/src/main/java/zerobase/bud/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package zerobase.bud.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -10,6 +11,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import zerobase.bud.domain.Member;
 import zerobase.bud.post.dto.ScrapDto;
+import zerobase.bud.post.dto.SearchMyPagePost;
+import zerobase.bud.post.service.PostService;
 import zerobase.bud.post.service.ScrapService;
 import zerobase.bud.user.dto.FollowDto;
 import zerobase.bud.user.dto.UserDto;
@@ -24,7 +27,11 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+
     private final ScrapService scrapService;
+
+
+    private final PostService postService;
 
     @PostMapping("/{userId}/follows")
     private ResponseEntity<URI> follow(@PathVariable Long userId,
@@ -79,5 +86,16 @@ public class UserController {
     @DeleteMapping("/posts/scraps/{scrapId}")
     public ResponseEntity<Long> removeScrap(@PathVariable Long scrapId) {
         return ResponseEntity.ok(scrapService.removeScrap(scrapId));
+    }
+
+    @GetMapping("/{my-page-userId}/posts")
+    public ResponseEntity<Page<SearchMyPagePost.Response>> searchMyPosts(
+            @AuthenticationPrincipal Member member,
+            @PathVariable("my-page-userId") Long myPageUserId,
+            @PageableDefault(size = 5, sort = "DATE", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(postService.searchMyPagePosts(member,
+                myPageUserId, pageable));
     }
 }

--- a/user-api/src/test/java/zerobase/bud/post/controller/PostControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/PostControllerTest.java
@@ -23,16 +23,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
-import zerobase.bud.comment.domain.Comment;
 import zerobase.bud.comment.service.CommentService;
 import zerobase.bud.jwt.TokenProvider;
+import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.dto.CommentDto;
-import zerobase.bud.post.dto.PostDto;
+import zerobase.bud.post.dto.SearchPost;
 import zerobase.bud.post.service.PostService;
 import zerobase.bud.post.service.ScrapService;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
-import zerobase.bud.util.TimeUtil;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -184,10 +183,10 @@ class PostControllerTest {
     @DisplayName("성공 - 전체 게시글 검색")
     void success_searchPosts() throws Exception {
         //given
-        List<PostDto> list = new ArrayList<>();
+        List<SearchPost.Response> list = new ArrayList<>();
 
         for (int i = 1; i <= 3; i++) {
-            list.add(PostDto.builder()
+            list.add(SearchPost.Response.builder()
                     .id(i)
                     .title("제목" + i)
                     .imageUrls(new String[]{"url1", "url2"})
@@ -197,15 +196,15 @@ class PostControllerTest {
                     .scrapCount(i)
                     .hitCount(i)
                     .postStatus(
-                            i % 4 == 0 ? PostStatus.INACTIVE : PostStatus.ACTIVE)
+                            i % 3 == 0 ? PostStatus.INACTIVE : PostStatus.ACTIVE)
                     .postType(PostType.FEED)
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build());
         }
 
-        given(postService.searchPosts(anyString(), any(), any(), anyInt(),
-                anyInt()))
+        given(postService.searchPosts(any(), anyString(), any(), any(),
+                anyInt(), anyInt(), any()))
                 .willReturn(new PageImpl<>(list));
 
         //when
@@ -296,7 +295,7 @@ class PostControllerTest {
     @DisplayName("성공 - 게시글 상세 정보 검색")
     void success_searchPost() throws Exception {
         //given
-        PostDto postDto = PostDto.builder()
+        SearchPost.Response response = SearchPost.Response.builder()
                 .id(1)
                 .title("제목")
                 .imageUrls(new String[]{"url1", "url2"})
@@ -311,8 +310,8 @@ class PostControllerTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        given(postService.searchPost(anyLong()))
-                .willReturn(postDto);
+        given(postService.searchPost(any(), anyLong()))
+                .willReturn(response);
         //when
         //then
 
@@ -369,10 +368,9 @@ class PostControllerTest {
     @DisplayName("성공 - 게시글 삭제")
     void success_deletePost() throws Exception {
         //given
-        PostDto postDto = PostDto.builder()
-                .id(1)
+        Post post = Post.builder()
+                .id((long)1)
                 .title("제목")
-                .imageUrls(new String[]{"url1", "url2"})
                 .content("내용")
                 .commentCount(1)
                 .likeCount(1)
@@ -385,7 +383,7 @@ class PostControllerTest {
                 .build();
 
         given(postService.deletePost(anyLong()))
-                .willReturn(postDto.getId());
+                .willReturn(post.getId());
         //when
         //then
 

--- a/user-api/src/test/java/zerobase/bud/user/UserControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/user/UserControllerTest.java
@@ -1,7 +1,5 @@
 package zerobase.bud.user;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,28 +10,27 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
-import zerobase.bud.domain.Member;
 import zerobase.bud.jwt.TokenProvider;
-import zerobase.bud.post.dto.PostDto;
+import zerobase.bud.post.dto.ScrapDto;
+import zerobase.bud.post.dto.SearchMyPagePost;
+import zerobase.bud.post.dto.SearchPost;
+import zerobase.bud.post.service.PostService;
+import zerobase.bud.post.service.ScrapService;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
-import zerobase.bud.post.dto.ScrapDto;
-import zerobase.bud.post.service.ScrapService;
-import zerobase.bud.type.MemberStatus;
 import zerobase.bud.user.controller.UserController;
 import zerobase.bud.user.dto.FollowDto;
 import zerobase.bud.user.dto.UserDto;
@@ -42,7 +39,6 @@ import zerobase.bud.user.service.UserService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -70,6 +66,9 @@ class UserControllerTest {
 
     @MockBean
     private ScrapService scrapService;
+
+    @MockBean
+    private PostService postService;
 
     @MockBean
     private TokenProvider tokenProvider;
@@ -494,16 +493,16 @@ class UserControllerTest {
     @DisplayName("성공 - 마이페이지 스크랩 불러오기")
     void successSearchScrap() throws Exception {
         //given
-        List<PostDto> postDtos = new ArrayList<>();
+        List<SearchPost.Response> list = new ArrayList<>();
 
         for (int i = 1; i <= 3; i++) {
-            postDtos.add(PostDto.builder()
+            list.add(SearchPost.Response.builder()
                     .id(i)
                     .title("제목" + i)
-                    .imageUrls(new String[]{"url1", "url2"})
                     .content("내용" + i)
                     .member(null)
                     .commentCount(i)
+                    .imageUrls(getImageUrlList(3))
                     .likeCount(i)
                     .scrapCount(i)
                     .hitCount(i)
@@ -519,7 +518,7 @@ class UserControllerTest {
         for (int i = 1; i <= 3; i++) {
             scrapDtos.add(ScrapDto.builder()
                     .id((long)i)
-                    .post(postDtos.get(i - 1))
+                    .post(list.get(i - 1))
                     .createdAt(LocalDateTime.now().plusDays(1))
                     .build());
         }
@@ -541,8 +540,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("content[0].post.title").value("제목1"))
                 .andExpect(jsonPath("content[0].post.scrapCount").value("1"))
                 .andExpect(jsonPath("content[0].post.content").value("내용1"))
-                .andExpect(jsonPath("content[0].post.imageUrls[0]").value("url1"))
-                .andExpect(jsonPath("content[0].post.imageUrls[1]").value("url2"))
+                .andExpect(jsonPath("content[0].post.imageUrls[0]").value("img0"))
+                .andExpect(jsonPath("content[0].post.imageUrls[1]").value("img1"))
                 .andExpect(jsonPath("content[0].post.postStatus").value("ACTIVE"))
                 .andExpect(jsonPath("content[0].id").value("1"))
                 .andDo(
@@ -595,5 +594,123 @@ class UserControllerTest {
                                 preprocessResponse(prettyPrint())
                         )
                 );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("성공 - 마이페이지 작성한 게시글들 불러오기")
+    void successSearchMyPagePosts() throws Exception {
+        //given
+        List<SearchMyPagePost.Response> list = new ArrayList<>();
+
+        for (int i = 1; i <= 3; i++) {
+            list.add(SearchMyPagePost.Response.builder()
+                    .postId(i)
+                    .title("제목")
+                    .postRegisterMemberId(1)
+                    .postRegisterMemberId(i)
+                    .imageUrls(getImageUrlList(3))
+                    .content("내용")
+                    .commentCount(i)
+                    .likeCount(i)
+                    .scrapCount(i)
+                    .hitCount(i)
+                    .postStatus(PostStatus.ACTIVE)
+                    .postType(PostType.FEED)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .isLike(true)
+                    .isFollow(false)
+                    .isScrap(true)
+                    .build());
+        }
+
+        given(postService.searchMyPagePosts(any(), anyLong(), any()))
+                .willReturn(new PageImpl<>(list, PageRequest.of(0, 3), 3));
+
+        //when
+        //then
+        mockMvc.perform(get("/users/2/posts")
+                        .param("size", "3")
+                        .param("page", "0")
+                        .param("sort", "DATE,DESC")
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content[0].title").value("제목"))
+                .andExpect(jsonPath("content[0].content").value("내용"))
+                .andExpect(jsonPath("content[0].postRegisterMemberId").value(1))
+                .andExpect(jsonPath("content[0].imageUrls[0]").value("img0"))
+                .andExpect(jsonPath("content[0].imageUrls[1]").value("img1"))
+                .andExpect(jsonPath("content[0].imageUrls[2]").value("img2"))
+                .andExpect(jsonPath("content[0].postStatus").value("ACTIVE"))
+                .andExpect(jsonPath("content[0].postType").value("FEED"))
+                .andExpect(jsonPath("content[0].like").value(true))
+                .andExpect(jsonPath("content[0].scrap").value(true))
+                .andExpect(jsonPath("content[0].follow").value(false))
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                relaxedResponseFields(
+                                        fieldWithPath("content[].postId").type(JsonFieldType.NUMBER)
+                                                .description("게시글 고유 번호"),
+                                        fieldWithPath("content[].title").type(JsonFieldType.STRING)
+                                                .description("게시글 제목"),
+                                        fieldWithPath("content[].postRegisterMemberId").type(JsonFieldType.NUMBER)
+                                                .description("게시글 작성자 고유 번호"),
+                                        fieldWithPath("content[].imageUrls").type(JsonFieldType.ARRAY)
+                                                .description("게시글 이미지 링크들"),
+                                        fieldWithPath("content[].content").type(JsonFieldType.STRING)
+                                                .description("게시글 본문"),
+                                        fieldWithPath("content[].commentCount").type(JsonFieldType.NUMBER)
+                                                .description("게시글 댓글 수"),
+                                        fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER)
+                                                .description("게시글 좋아요 수"),
+                                        fieldWithPath("content[].scrapCount").type(JsonFieldType.NUMBER)
+                                                .description("게시글 스크랩 수"),
+                                        fieldWithPath("content[].hitCount").type(JsonFieldType.NUMBER)
+                                                .description("게시글 조회수"),
+                                        fieldWithPath("content[].postStatus").type(JsonFieldType.STRING)
+                                                .description("게시글 상태"),
+                                        fieldWithPath("content[].postType").type(JsonFieldType.STRING)
+                                                .description("게시글 종류"),
+                                        fieldWithPath("content[].createdAt").type(JsonFieldType.STRING)
+                                                .description("게시글 등록일"),
+                                        fieldWithPath("content[].updatedAt").type(JsonFieldType.STRING)
+                                                .description("게시글 수정일"),
+                                        fieldWithPath("content[].like").type(JsonFieldType.BOOLEAN)
+                                                .description("해당 게시글 좋아요 여부"),
+                                        fieldWithPath("content[].scrap").type(JsonFieldType.BOOLEAN)
+                                                .description("해당 게시글 스크랩 여부"),
+                                        fieldWithPath("content[].follow").type(JsonFieldType.BOOLEAN)
+                                                .description("해당 게시글 작성자를 본인이 팔로우 했는지 여부"),
+                                        fieldWithPath("first").type(JsonFieldType.BOOLEAN)
+                                                .description("첫번째 페이지 여부"),
+                                        fieldWithPath("last").type(JsonFieldType.BOOLEAN)
+                                                .description("마지막 페이지 여부"),
+                                        fieldWithPath("totalElements").type(JsonFieldType.NUMBER)
+                                                .description("검색 데이터 전체 개수"),
+                                        fieldWithPath("totalPages").type(JsonFieldType.NUMBER)
+                                                .description("검색 데이터 전체 페이지 수"),
+                                        fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                                .description("요청 데이터 수"),
+                                        fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지에서 보여지는 데이터 수")
+                                )
+                        )
+                );
+    }
+
+    private static String[] getImageUrlList(int size) {
+        String[] images = new String[size];
+
+        for (int i = 0; i < size; i++) {
+            images[i] = "img" + i;
+        }
+
+        return images;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 마이페이지 게시글 조회 기능 추가
- 게시글 응답데이터에 좋아요, 스크랩 유무, 작성자 팔로우 유무 확인 데이터 추가
- 게시글 목록 조회시 게시글 타입 필터 추가
- 응답데이터 변경사항에 맞게 postDto 리펙토링
- 마이페이지 게시글 조회 테스터 추가
- 변경사항에 맞게 테스트 코드 변경
- api 문서 (adoc) 수정

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
2023.04.20
