### PR TITLE
[Feat-ChangeNotificationAvailable] 유저 마이페이지 -> 상세 페이지 -> 알림 푸쉬 허용 변경하는 기능

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -899,6 +899,32 @@ include::{snippets}/user-controller-test/success-delete-scrap/http-request.adoc[
 .response
 include::{snippets}/user-controller-test/success-delete-scrap/http-response.adoc[]
 
+=== 10. 알림 푸쉬 설정 변경
+.request
+include::{snippets}/user-controller-test/success_change-notification-available/http-request.adoc[]
+
+.request example
+|===
+|url|예시
+|/users/{userId}/notification-info|/users/1/notification-info
+|===
+
+.request field
+|===
+|필드명|타입|필수여부|설명|기본값
+|isPostPushAvailable|Boolean|N|게시물 푸쉬 허용 여부|기존값
+|isFollowPushAvailable|Boolean|N|게시물 푸쉬 허용 여부|기존값
+|===
+
+.response
+include::{snippets}/user-controller-test/success_change-notification-available/http-response.adoc[]
+
+.response field
+|===
+|필드명|설명
+|nickName|유저의 닉네임
+|===
+
 == 알림 API
 === 1. 알림 조회
 .request

--- a/user-api/src/main/java/zerobase/bud/notification/domain/NotificationInfo.java
+++ b/user-api/src/main/java/zerobase/bud/notification/domain/NotificationInfo.java
@@ -1,5 +1,6 @@
 package zerobase.bud.notification.domain;
 
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -12,6 +13,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import zerobase.bud.domain.BaseEntity;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.dto.NotificationInfoDto;
 import zerobase.bud.notification.dto.SaveNotificationInfo;
 
 @Getter
@@ -46,4 +48,13 @@ public class NotificationInfo extends BaseEntity {
     }
 
 
+    public void updateAvailable(NotificationInfoDto notificationInfoDto) {
+        if (Objects.nonNull(notificationInfoDto.getIsFollowPushAvailable())) {
+            isFollowPushAvailable = notificationInfoDto.getIsFollowPushAvailable();
+        }
+
+        if (Objects.nonNull(notificationInfoDto.getIsPostPushAvailable())) {
+            isPostPushAvailable = notificationInfoDto.getIsPostPushAvailable();
+        }
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/notification/dto/NotificationInfoDto.java
+++ b/user-api/src/main/java/zerobase/bud/notification/dto/NotificationInfoDto.java
@@ -1,0 +1,20 @@
+package zerobase.bud.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationInfoDto {
+
+    private Boolean isPostPushAvailable;
+
+    private Boolean isFollowPushAvailable;
+
+}

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationInfoService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationInfoService.java
@@ -3,8 +3,11 @@ package zerobase.bud.notification.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zerobase.bud.common.exception.BudException;
+import zerobase.bud.common.type.ErrorCode;
 import zerobase.bud.domain.Member;
 import zerobase.bud.notification.domain.NotificationInfo;
+import zerobase.bud.notification.dto.NotificationInfoDto;
 import zerobase.bud.notification.dto.SaveNotificationInfo;
 import zerobase.bud.notification.repository.NotificationInfoRepository;
 
@@ -23,5 +26,18 @@ public class NotificationInfoService {
                     () -> notificationInfoRepository.save(NotificationInfo.of(request, member)));
 
         return request.getFcmToken();
+    }
+
+    @Transactional
+    public String changeNotificationAvailable(
+        NotificationInfoDto notificationInfoDto, Member member
+    ) {
+        NotificationInfo notificationInfo =
+            notificationInfoRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new BudException(ErrorCode.NOT_FOUND_NOTIFICATION_INFO));
+
+        notificationInfo.updateAvailable(notificationInfoDto);
+
+        return notificationInfo.getMember().getNickname();
     }
 }

--- a/user-api/src/main/java/zerobase/bud/user/controller/UserController.java
+++ b/user-api/src/main/java/zerobase/bud/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package zerobase.bud.user.controller;
 
+import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -7,16 +9,22 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.dto.NotificationInfoDto;
+import zerobase.bud.notification.service.NotificationInfoService;
 import zerobase.bud.post.dto.ScrapDto;
 import zerobase.bud.post.service.ScrapService;
 import zerobase.bud.user.dto.FollowDto;
 import zerobase.bud.user.dto.UserDto;
 import zerobase.bud.user.service.UserService;
-
-import java.net.URI;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,6 +33,7 @@ public class UserController {
 
     private final UserService userService;
     private final ScrapService scrapService;
+    private final NotificationInfoService notificationInfoService;
 
     @PostMapping("/{userId}/follows")
     private ResponseEntity<URI> follow(@PathVariable Long userId,
@@ -79,5 +88,15 @@ public class UserController {
     @DeleteMapping("/posts/scraps/{scrapId}")
     public ResponseEntity<Long> removeScrap(@PathVariable Long scrapId) {
         return ResponseEntity.ok(scrapService.removeScrap(scrapId));
+    }
+
+    @PutMapping("/{userId}/notification-info")
+    public ResponseEntity<String> changeNotificationAvailable(
+        @RequestBody NotificationInfoDto notificationInfoDto,
+        @AuthenticationPrincipal Member member
+    ){
+        return ResponseEntity.ok(notificationInfoService.changeNotificationAvailable(
+            notificationInfoDto, member
+        ));
     }
 }

--- a/user-api/src/test/java/zerobase/bud/notification/service/NotificationInfoServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/service/NotificationInfoServiceTest.java
@@ -1,21 +1,27 @@
 package zerobase.bud.notification.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION_INFO;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import zerobase.bud.common.exception.BudException;
 import zerobase.bud.domain.Member;
 import zerobase.bud.notification.domain.NotificationInfo;
+import zerobase.bud.notification.dto.NotificationInfoDto;
 import zerobase.bud.notification.dto.SaveNotificationInfo.Request;
 import zerobase.bud.notification.repository.NotificationInfoRepository;
 
@@ -29,7 +35,7 @@ class NotificationInfoServiceTest {
     private NotificationInfoService notificationInfoService;
 
     @Test
-    void saveNotificationInfo() {
+    void success_saveNotificationInfo() {
         //given
         given(notificationInfoRepository.save(any()))
             .willReturn(NotificationInfo.builder()
@@ -55,10 +61,48 @@ class NotificationInfoServiceTest {
         assertEquals("fcmToken", fcmToken);
     }
 
+    @Test
+    void success_changeNotificationAvailable() {
+        //given
+        given(notificationInfoRepository.findByMemberId(any()))
+            .willReturn(Optional.ofNullable(NotificationInfo.builder()
+                .fcmToken("fcmToken")
+                .isPostPushAvailable(true)
+                .isFollowPushAvailable(true)
+                .member(getMember())
+                .build()));
+
+        //when
+        String nickName = notificationInfoService.changeNotificationAvailable(
+            new NotificationInfoDto(
+                 true, false
+            ), getMember()
+        );
+        //then
+        assertEquals("nickname", nickName);
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND_NOTIFICATION_INFO_changeNotificationAvailable")
+    void NOT_FOUND_NOTIFICATION_INFO_changeNotificationAvailable() {
+        //given
+        given(notificationInfoRepository.findByMemberId(any()))
+            .willReturn(Optional.empty());
+
+        //when
+        BudException budException = assertThrows(BudException.class
+            , () -> notificationInfoService.changeNotificationAvailable(
+                new NotificationInfoDto(true, false)
+                , getMember()
+            ));
+        //then
+        assertEquals(NOT_FOUND_NOTIFICATION_INFO, budException.getErrorCode());
+    }
+
     private Member getMember() {
         return Member.builder()
             .id(1L)
-            .nickname("member")
+            .nickname("nickname")
             .userId("member")
             .createdAt(LocalDateTime.now().minusDays(1))
             .build();


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - 마이 페이지에서 유저가 알림의 푸쉬 허용 여부를 변경하는 api를 만들었습니다.(게시물, 팔로우 관련 알람 허용 여부)
- 변경 사항 2
  - 테스트코드 작성
  
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 20. Thu`
