### PR TITLE
실시간 채팅시 유저 아이디 잘못 반환하는 버그 수정

### DIFF
--- a/chat-api/src/main/java/zerobase/bud/dto/ChatDto.java
+++ b/chat-api/src/main/java/zerobase/bud/dto/ChatDto.java
@@ -25,7 +25,7 @@ public class ChatDto implements Serializable {
     private String imageUrl;
     private String userProfileUrl;
     private String userName;
-    private long numberOfMembers;
+    private Long numberOfMembers;
     private Long userId;
 
     public static ChatDto from(Chat chat) {
@@ -37,7 +37,7 @@ public class ChatDto implements Serializable {
                 .message(chat.getMessage())
                 .userName(chat.getMember().getNickname())
                 .userProfileUrl(chat.getMember().getProfileImg())
-                .userId(chat.getId())
+                .userId(chat.getMember().getId())
                 .build();
     }
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 실시간 채팅시 유저 아이디 잘못 반환하는 버그 수정

