### PR TITLE
채팅 유저 아이디 잘못 반환하는 버그 수정

### DIFF
--- a/user-api/src/main/java/zerobase/bud/chat/dto/ChatDto.java
+++ b/user-api/src/main/java/zerobase/bud/chat/dto/ChatDto.java
@@ -38,7 +38,7 @@ public class ChatDto implements Serializable {
                 .message(chat.getMessage())
                 .userName(chat.getMember().getNickname())
                 .userProfileUrl(chat.getMember().getProfileImg())
-                .userId(chat.getId())
+                .userId(chat.getMember().getId())
                 .isReader(isReader)
                 .build();
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- 채팅 유저 아이디 잘못 반환하는 버그 수정
- user-api 하위에도 수정 사항 반영
