### PR TITLE
[Feat-UnreadNotificationCount] 사용자가 읽지 않은 알림 수 반환

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -1058,6 +1058,16 @@ include::{snippets}/notification-controller-test/success_delete-notification/htt
 .response field
 include::{snippets}/notification-controller-test/success_delete-notification/response-body.adoc[]
 
+=== 4. 읽지 않은 알림의 수 반환
+.request
+include::{snippets}/notification-controller-test/success_get-unread-notification-count/http-request.adoc[]
+
+.response
+include::{snippets}/notification-controller-test/success_get-unread-notification-count/http-response.adoc[]
+
+.response field
+include::{snippets}/notification-controller-test/success_get-unread-notification-count/response-body.adoc[]
+
 
 == 파이어베이스토큰 API
 === 1. 파이어베이스토큰 저장

--- a/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
+++ b/user-api/src/main/java/zerobase/bud/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package zerobase.bud.notification.controller;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -32,6 +33,13 @@ public class NotificationController {
         @PageableDefault(sort = SORTING_CRITERIA , direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(notificationService.getNotifications(member, pageable));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<Map<String, Long>> getUnreadNotificationCount(
+        @AuthenticationPrincipal Member member
+    ) {
+        return ResponseEntity.ok(notificationService.getUnreadNotificationCount(member));
     }
 
     @PutMapping("/{notificationId}/read")

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.notification.domain.Notification;
+import zerobase.bud.notification.type.NotificationStatus;
 
 @Repository
 public interface NotificationRepository extends
@@ -14,4 +15,6 @@ public interface NotificationRepository extends
     Slice<Notification> findAllByReceiverId(Long receiverId, Pageable pageable);
 
     Optional<Notification> findByNotificationId(String notificationId);
+
+    long countByReceiverIdAndNotificationStatus(Long receiverId, NotificationStatus unread);
 }

--- a/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
+++ b/user-api/src/main/java/zerobase/bud/notification/service/NotificationService.java
@@ -2,7 +2,9 @@ package zerobase.bud.notification.service;
 
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION;
 import static zerobase.bud.common.type.ErrorCode.NOT_RECEIVED_NOTIFICATION_MEMBER;
+import static zerobase.bud.notification.type.NotificationStatus.UNREAD;
 
+import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +25,18 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
 
+    private final static String UNREAD_COUNT = "unreadCount";
+
 
     public Slice<Response> getNotifications(Member member, Pageable pageable) {
         return notificationRepository
             .findAllByReceiverId(member.getId(), pageable)
             .map(Response::fromEntity);
+    }
+
+    public Map<String, Long> getUnreadNotificationCount(Member member) {
+        return Map.of( UNREAD_COUNT
+            , notificationRepository.countByReceiverIdAndNotificationStatus(member.getId(), UNREAD));
     }
 
 

--- a/user-api/src/test/java/zerobase/bud/notification/controller/NotificationControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/controller/NotificationControllerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,6 +98,31 @@ class NotificationControllerTest {
                 "ANSWER"))
             .andExpect(
                 jsonPath("$.content.[0].notificationStatus").value("UNREAD"))
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
+
+    }
+
+    @Test
+    @WithMockUser
+    void success_getUnreadNotificationCount() throws Exception {
+        //given
+        given(notificationService.getUnreadNotificationCount(any()))
+            .willReturn(Map.of("unreadCount", 3L));
+
+        //when 어떤 경우에
+        //then 이런 결과가 나온다.
+        mockMvc.perform(get("/notifications/unread-count")
+                .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(
+                jsonPath("unreadCount").value(3))
             .andDo(
                 document("{class-name}/{method-name}",
                     preprocessRequest(prettyPrint()),

--- a/user-api/src/test/java/zerobase/bud/notification/service/NotificationServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/notification/service/NotificationServiceTest.java
@@ -2,6 +2,8 @@ package zerobase.bud.notification.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static zerobase.bud.common.type.ErrorCode.NOT_FOUND_NOTIFICATION;
@@ -11,6 +13,7 @@ import static zerobase.bud.util.Constants.REPLACE_EXPRESSION;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -71,6 +74,18 @@ class NotificationServiceTest {
             notificationResponse.getNotificationDetailType());
         assertEquals(NotificationStatus.UNREAD,
             notificationResponse.getNotificationStatus());
+    }
+
+    @Test
+    void success_UnreadNotificationCount() {
+        //given 어떤 데이터가 주어졌을 때
+        given(notificationRepository.countByReceiverIdAndNotificationStatus(anyLong(), any()))
+            .willReturn(3L);
+        //when 어떤 경우에
+        Map<String,Long> resultMap = notificationService.getUnreadNotificationCount(
+            getReceiver());
+        //then 이런 결과가 나온다.
+        assertEquals(3, resultMap.get("unreadCount"));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - 사용자가 읽지 않은 알림 수를 반환해주는 API ( 프론트 요구사항)
- 변경 사항 2
   - 테스트코드 구현
   
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 23. Sun`

## 참고사항
제가 이 부분을 원래 알림 리스트를 보낼 때 같이 보내줄까 하다가 따로 분리하였는데요
그 이유는 현재 아래처럼 알림 리스트들이 가고 있는데요,
이 content 안에서 count와 알림 정보리스트들을 나누어 보내야하는데 
그렇게 하기 위해선 알림 정보리스트들을 또 다른 객체로 묶던가 해야할 것 같은데 
그게 효율적이지 않을 것 같아서 분리하였습니다.

---

"content": [
        {
            "senderId": 2,
            "senderNickName": "JHni2",
            "senderProfileImage": null,
            "notificationId": "2909dbbd94da41d7a98f3f5c4f76cb6520230421182741975",
            "notificationType": "POST",
            "pageType": "QNA",
            "pageId": 73,
            "notificationDetailType": "ANSWER_PIN",
            "notificationStatus": "UNREAD",
            "notifiedAt": "2023-04-21T18:27:41.967606"
        }
]

---

이 방법이 괜찮은 건지 확신 할 수 없어서 여러분의 의견을 남겨주시면 감사하겠습니다!!
