### PR TITLE
refactor : [Refactor-Chore] 리팩토링

### DIFF
--- a/user-api/src/main/java/zerobase/bud/config/AsyncConfig.java
+++ b/user-api/src/main/java/zerobase/bud/config/AsyncConfig.java
@@ -20,8 +20,7 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("Async-"); // thread 이름 설정
         executor.setCorePoolSize(processors); // 기본 스레드 수
         executor.setMaxPoolSize(processors*2); // 최대 스레드 개수
-        executor.setQueueCapacity(50); // 최대 큐 수
-        executor.setKeepAliveSeconds(60); // maxpoolsize로 인해 덤으로 더 돌아다니는 튜브는 60초 후에 수거해서 정리
+        executor.setQueueCapacity(processors*6); // 최대 큐 수
         executor.initialize(); // 초기화후 반환
         return executor;
     }

--- a/user-api/src/main/java/zerobase/bud/post/repository/ImageRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/ImageRepository.java
@@ -1,6 +1,8 @@
 package zerobase.bud.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.post.domain.Image;
 
@@ -8,6 +10,9 @@ import java.util.List;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    @Modifying
+    @Query(value = "delete from image where post_id=:postId" , nativeQuery = true)
     void deleteAllByPostId(Long postId);
     List<Image> findAllByPostId(Long postId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerImageRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerImageRepository.java
@@ -1,10 +1,15 @@
 package zerobase.bud.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.post.domain.QnaAnswerImage;
 
 @Repository
 public interface QnaAnswerImageRepository extends JpaRepository<QnaAnswerImage, Long> {
+
+    @Modifying
+    @Query(value = "delete from qna_answer_image where qna_answer_id=:qnaAnswerId" , nativeQuery = true)
     void deleteAllByQnaAnswerId(Long qnaAnswerId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/service/PostService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/PostService.java
@@ -213,10 +213,8 @@ public class PostService {
     }
 
     private void deleteImages(Post post) {
-        List<Image> imageList = post.getImages();
-        for (Image image : imageList) {
-            awsS3Api.deleteImage(image.getImagePath());
-        }
+        post.getImages()
+            .forEach(image -> awsS3Api.deleteImage(image.getImagePath()));
 
         imageRepository.deleteAllByPostId(post.getId());
     }

--- a/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/QnaAnswerService.java
@@ -124,10 +124,8 @@ public class QnaAnswerService {
     }
 
     private void deleteImages(QnaAnswer qnaAnswer) {
-        List<QnaAnswerImage> imageList = qnaAnswer.getQnaAnswerImages();
-        for (QnaAnswerImage image : imageList) {
-            awsS3Api.deleteImage(image.getImagePath());
-        }
+        qnaAnswer.getQnaAnswerImages()
+            .forEach(qnaAnswerImage -> awsS3Api.deleteImage(qnaAnswerImage.getImagePath()));
 
         qnaAnswerImageRepository.deleteAllByQnaAnswerId(qnaAnswer.getId());
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 1
   - AsyncConfig => setKeepAliveSeconds 의 default가 60초이므로 굳이 넣을 필요 x , QueueCapcity의 경우 보통 MaxPoolSize의 
      2~3배를 잡는다고 하여 변경했습니다. (정석은 성능테스트를 통해 최적의 값을 찾아야한다고합니다..)
- 변경 사항 2
   - JPA DELETEALLBYID를 그냥 쓰면 단건 삭제들이 이루어지기 때문에 성능을 위해 native Query 를 통해 하나의 쿼리로 삭제가 
     되는 것이 나을 것이기에 수정하였습니다.
## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 24. Mon`
