### PR TITLE
feat#179: 회원 탈퇴 및 유저 정보 변경 적용

### DIFF
--- a/core/src/main/java/zerobase/bud/type/MemberStatus.java
+++ b/core/src/main/java/zerobase/bud/type/MemberStatus.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberStatus {
     VERIFIED("ROLE_VERIFIED", "인증된 회원"),
-    BLOCKED("ROLE_BLOCKED", "차단된 회원");
+    BLOCKED("ROLE_BLOCKED", "차단된 회원"),
+    WITHDREW("ROLE_WITHDREW", "탈퇴한 회원");
 
     private final String key;
     private final String status;

--- a/user-api/src/main/java/zerobase/bud/member/controller/MemberController.java
+++ b/user-api/src/main/java/zerobase/bud/member/controller/MemberController.java
@@ -31,4 +31,9 @@ public class MemberController {
     public ResponseEntity<List<String>> getLevelImage(@AuthenticationPrincipal Member member) {
         return ResponseEntity.ok(memberService.getLevelImage(member));
     }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<?> withdrawMember(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(memberService.withdrawMember(member));
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/user/repository/FollowRepository.java
+++ b/user-api/src/main/java/zerobase/bud/user/repository/FollowRepository.java
@@ -7,7 +7,6 @@ import zerobase.bud.domain.Member;
 import zerobase.bud.user.domain.Follow;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
@@ -24,4 +23,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByTargetAndMember(Member target, Member member);
 
     List<Follow> findAllByTargetId(Long senderId);
+
+    void deleteAllByMember(Member member);
+    void deleteAllByTarget(Member target);
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 회원 탈퇴 시 회원 이름 정보를 Random한 UUID값으로 변경
- 회원 탈퇴 시 팔로우, 팔로워 정보를 제거

## Merge 전 필요 작업 (Checklist before merge)
- 회원 탈퇴 API를 실제 삭제가 아닌 수정이 이루어지는 과정이므로 POST로 지정해두었는데, 가독성에 따라 DELETE가 더 낫다 싶으면 Merge 전에 수정하도록 하겠습니다. 의견 남겨주세요!
- 팔로우, 팔로워 정보를 지우는 과정이 포함되었는데, 테스트 결과는 괜찮았지만 제가 고려하지 못한 추가적인 문제가 있을 수도 있으니 한 번 확인 부탁드립니다.

## 희망 리뷰 완료 일 (Expected due date)
