### PR TITLE
게시글 삭제 정책에 맞게 변경했습니다.

### DIFF
--- a/user-api/src/main/java/zerobase/bud/post/repository/PostRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package zerobase.bud.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.domain.Member;
 import zerobase.bud.post.domain.Post;
@@ -14,4 +16,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByIdAndPostStatus(Long id, PostStatus postStatus);
 
+    @Modifying
+    @Query(value = "delete from post where id=:postId" , nativeQuery = true)
+    void deleteAllByPostId(Long postId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Repository;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.type.QnaAnswerStatus;
 
+import java.util.List;
+
 @Repository
 public interface QnaAnswerRepository extends JpaRepository<QnaAnswer, Long> {
     Optional<QnaAnswer> findByIdAndQnaAnswerStatus(Long id, QnaAnswerStatus qnaAnswerStatus);
 
+    List<QnaAnswer> findAllByPostId(Long postId);
 }

--- a/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
@@ -388,15 +388,12 @@ class PostServiceTest {
         given(postRepository.findById(anyLong()))
                 .willReturn(Optional.of(post));
 
-        ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
-
         //when
         Long id = postService.deletePost((long) 1);
 
         //then
-        verify(postRepository, times(1)).save(postCaptor.capture());
-        assertEquals(id, post.getId());
-        assertEquals(postCaptor.getValue().getPostStatus(), INACTIVE);
+        verify(postRepository, times(1)).deleteAllByPostId(any());
+        assertEquals(id, 1L);
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 (Content)
- 게시글 삭제 정책 반영
- 게시글 삭제 테스트 코드 수정

## 변경된 부분
- 게시글 삭제를 STATUS 변경 하는 부분을 게시글과 관련된 데이터를 완전 삭제하는것으로 변경했습니다.
- DB에 게시글과 관련된 테이블들에 CASCADE를 설정해줬습니다.

## 테스트
1. 게시글 관련 데이터를 로컬 데이터 베이스에 추가 한 후에 게시글이 삭제 되었는지 확인 했습니다.
2. Post, QnaAnswer 이미지가 S3에서 삭제 되는 것을 김한규 팀원과 같이 확인했습니다.

## 상의드릴 부분
PostService.java deletePost 함수 코드 부분에서 상의드릴 부분이 있습니다.

1. S3에 게시글 이미지를 게시글 데이터를 삭제하기 전에 삭제 하는데, 걱정되는 부분이 S3에 이미지가 다 삭제 되고 나서 어떤 문제로 인해 Transaction이 동작하여 게시글 데이터는 삭제가 안되고 이미지만 삭제 되는 부분이 걱정이 됩니다.
- 생각한 해결방안: 우선 post imagePath와 qnaAnswer imagePath를 미리 받아놓고 게시글 데이터가 삭제가 되면 미리 받아놓은 데이터를 통해 S3를 삭제하는 것입니다. 하지만 이렇게 하면 코드가 지저분해지는게 문제입니다.

2.  post 게시글을 삭제 할 때, post Image는 반복문 한번(O(n))으로 삭제가 가능 하지만, qnaAnswerImage는 이중 포문(O(n^2))으로 삭제를 해야해서 이미지가 많은 게시글이면 성능에 문제가 있을것 같습니다!
혹시나 더 좋은 방법이 있으면 말씀해 주시면 적극 반영해 보겠습니다!


## 희망 리뷰 완료 일 (Expected due date)
2023.04.27
