### PR TITLE
[Refactor-getProfileRandomImage] 랜덤 프로필 이미지 관련 로직 수정

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -806,10 +806,6 @@ include::{snippets}/qna-answer-controller-test/success_cancel-qna-answer-pin/htt
 |qnaAnswerPinId|Number|Y|path variable, QnA답글 핀의 Id
 |===
 
-=== 27. 댓글 생성
-.request
-include::{snippets}/post-controller-test/success-create-comment/http-request.adoc[]
-
 .request field
 |===
 |필드명|타입|필수여부|설명
@@ -1039,6 +1035,19 @@ include::{snippets}/user-controller-test/success_change-notification-available/h
 |===
 |필드명|설명
 |nickName|유저의 닉네임
+|===
+
+=== 12. 랜덤 이미지 가져오는 것
+.request
+include::{snippets}/member-controller-test/success_get-profile-random-image/http-request.adoc[]
+
+.response
+include::{snippets}/member-controller-test/success_get-profile-random-image/http-response.adoc[]
+
+.response field
+|===
+|필드명|설명
+|profile_img|기본 프로필 이미지 경로
 |===
 
 == 알림 API

--- a/user-api/src/main/java/zerobase/bud/member/controller/MemberController.java
+++ b/user-api/src/main/java/zerobase/bud/member/controller/MemberController.java
@@ -32,9 +32,9 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getLevelImage(member));
     }
 
-    @PostMapping("/random-image")
-    public ResponseEntity<String> updateProfileRandomImage(@AuthenticationPrincipal Member member) {
-        return ResponseEntity.ok(memberService.updateProfileRandomImage(member));
+    @GetMapping("/random-image")
+    public ResponseEntity<String> getProfileRandomImage() {
+        return ResponseEntity.ok(memberService.getProfileRandomImage());
     }
 
     @PostMapping("/withdraw")

--- a/user-api/src/main/java/zerobase/bud/member/service/MemberService.java
+++ b/user-api/src/main/java/zerobase/bud/member/service/MemberService.java
@@ -69,16 +69,10 @@ public class MemberService implements UserDetailsService {
         return levelArray;
     }
 
-    public String updateProfileRandomImage(Member member) {
+    public String getProfileRandomImage() {
         Random rd = new Random();
         int randomNumber = rd.nextInt(32) + 1;
-
-        String imagePath = PROFILE_BASIC_IMAGE_PREFIX + randomNumber + FILE_EXTENSION_PNG;
-
-        member.updateProfileImage(imagePath);
-        memberRepository.save(member);
-
-        return imagePath;
+        return PROFILE_BASIC_IMAGE_PREFIX + randomNumber + FILE_EXTENSION_PNG;
     }
 
     @Transactional

--- a/user-api/src/test/java/zerobase/bud/member/controller/MemberControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/member/controller/MemberControllerTest.java
@@ -1,0 +1,68 @@
+package zerobase.bud.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import zerobase.bud.jwt.TokenProvider;
+import zerobase.bud.member.service.MemberService;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureRestDocs
+class MemberControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final static String TOKEN = "BEARER TOKEN";
+
+    @Test
+    @WithMockUser
+    void success_getProfileRandomImage() throws Exception {
+        //given
+
+        given(memberService.getProfileRandomImage())
+            .willReturn("profiles/basic/1.png");
+
+        //when 어떤 경우에
+        //then 이런 결과가 나온다.
+        mockMvc.perform(get("/member/random-image")
+                .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").value("profiles/basic/1.png"))
+            .andDo(
+                document("{class-name}/{method-name}",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()))
+            );
+    }
+}

--- a/user-api/src/test/java/zerobase/bud/member/service/MemberServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/member/service/MemberServiceTest.java
@@ -1,0 +1,32 @@
+package zerobase.bud.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zerobase.bud.awsS3.AwsS3Api;
+import zerobase.bud.repository.MemberRepository;
+import zerobase.bud.user.repository.FollowRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private FollowRepository followRepository;
+    @Mock
+    private AwsS3Api awsS3Api;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    void getProfileRandomImage() {
+        String profileRandomImage = memberService.getProfileRandomImage();
+        assertNotNull(profileRandomImage);
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항 
   - 기존에 랜덤 프로필 이미지 가져올 때 바로 회원의 프로필 이미지를 바꿨었는데 업데이트 하지 않도록 수
   - 테스트 코드 작성

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 28. Fri`
