### PR TITLE
QNA ANSWER 삭제 기능 백엔드 정책에 맞게 수정

### DIFF
--- a/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/QnaAnswerController.java
@@ -129,7 +129,7 @@ public class QnaAnswerController {
             @AuthenticationPrincipal Member member
     ) {
         return ResponseEntity.ok(
-                qnaAnswerService.setLike(qnaAnswerId, member) ? "좋아요" : "좋아요 해제");
+                qnaAnswerService.addLike(qnaAnswerId, member) ? "좋아요" : "좋아요 해제");
     }
 
     @PostMapping("/{postId}/comments")

--- a/user-api/src/main/java/zerobase/bud/post/repository/PostRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/PostRepository.java
@@ -18,5 +18,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Modifying
     @Query(value = "delete from post where id=:postId" , nativeQuery = true)
-    void deleteAllByPostId(Long postId);
+    void deleteByPostId(Long postId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
+++ b/user-api/src/main/java/zerobase/bud/post/repository/QnaAnswerRepository.java
@@ -2,6 +2,8 @@ package zerobase.bud.post.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.post.domain.QnaAnswer;
 import zerobase.bud.post.type.QnaAnswerStatus;
@@ -13,4 +15,8 @@ public interface QnaAnswerRepository extends JpaRepository<QnaAnswer, Long> {
     Optional<QnaAnswer> findByIdAndQnaAnswerStatus(Long id, QnaAnswerStatus qnaAnswerStatus);
 
     List<QnaAnswer> findAllByPostId(Long postId);
+
+    @Modifying
+    @Query(value = "delete from qna_answer where id=:qnaAnswerId" , nativeQuery = true)
+    void deleteByQnaAnswerId(Long qnaAnswerId);
 }

--- a/user-api/src/main/java/zerobase/bud/post/service/PostService.java
+++ b/user-api/src/main/java/zerobase/bud/post/service/PostService.java
@@ -175,7 +175,7 @@ public class PostService {
             qnaAnswers.forEach(this::deleteQnaAnswerImagesFromS3);
         }
 
-        postRepository.deleteAllByPostId(post.getId());
+        postRepository.deleteByPostId(post.getId());
 
         return post.getId();
     }

--- a/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
@@ -582,7 +582,7 @@ class QnaAnswerControllerTest {
     @DisplayName("성공 - QNA Answer 좋아요")
     void success_addQnaAnswerLike() throws Exception {
         //given
-        given(qnaAnswerService.setLike(anyLong(), any()))
+        given(qnaAnswerService.addLike(anyLong(), any()))
                 .willReturn(true);
         //when
         //then
@@ -606,7 +606,7 @@ class QnaAnswerControllerTest {
     @DisplayName("성공 - QNA Answer 좋아요 해제")
     void success_removeQnaAnswerLike() throws Exception {
         //given
-        given(qnaAnswerService.setLike(anyLong(), any()))
+        given(qnaAnswerService.addLike(anyLong(), any()))
                 .willReturn(false);
         //when
         //then

--- a/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/PostServiceTest.java
@@ -392,7 +392,7 @@ class PostServiceTest {
         Long id = postService.deletePost((long) 1);
 
         //then
-        verify(postRepository, times(1)).deleteAllByPostId(any());
+        verify(postRepository, times(1)).deleteByPostId(any());
         assertEquals(id, 1L);
     }
 

--- a/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
@@ -664,10 +664,7 @@ class QnaAnswerServiceTest {
         qnaAnswerService.deleteQnaAnswer((long)1);
 
         //then
-        verify(qnaAnswerRepository, times(1))
-                .save(captor.capture());
-
-        assertEquals(QnaAnswerStatus.INACTIVE, captor.getValue().getQnaAnswerStatus());
+        verify(qnaAnswerRepository, times(1)).deleteByQnaAnswerId(anyLong());
     }
 
     @Test

--- a/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/service/QnaAnswerServiceTest.java
@@ -744,7 +744,7 @@ class QnaAnswerServiceTest {
         ArgumentCaptor<QnaAnswer> qnaAnswerCaptor = ArgumentCaptor.forClass(QnaAnswer.class);
 
         //when
-        boolean setLike = qnaAnswerService.setLike(qnaAnswer.getId(), member);
+        boolean setLike = qnaAnswerService.addLike(qnaAnswer.getId(), member);
 
         //then
         verify(qnaAnswerRepository, times(1)).save(qnaAnswerCaptor.capture());
@@ -774,7 +774,7 @@ class QnaAnswerServiceTest {
         ArgumentCaptor<QnaAnswer> qnaAnswerCaptor = ArgumentCaptor.forClass(QnaAnswer.class);
 
         //when
-        boolean setLike = qnaAnswerService.setLike(qnaAnswer.getId(), member);
+        boolean setLike = qnaAnswerService.addLike(qnaAnswer.getId(), member);
 
         //then
         verify(qnaAnswerRepository, times(1)).save(qnaAnswerCaptor.capture());
@@ -792,7 +792,7 @@ class QnaAnswerServiceTest {
 
         //when
         BudException budException = assertThrows(BudException.class,
-                () -> qnaAnswerService.setLike((long)1, new Member()));
+                () -> qnaAnswerService.addLike((long)1, new Member()));
 
         //then
         assertEquals(NOT_FOUND_QNA_ANSWER, budException.getErrorCode());


### PR DESCRIPTION
## 작업 내용 (Content)
- QNA ANSWER 삭제 기능 수정
- 테스트 코드 수정
- QNA ANSWER 좋아요 함수명 변경
- post 삭제 함수명 변경

## 변경된 부분
- 기존에 QNA ANSWER 삭제를 STATUS만 변경 하는것에서 지금은 데이터를 완전 삭제하는것으로 변경했습니다.

## 테스트
1. QNA ANSWER관련 데이터를 로컬 데이터 베이스에 추가 한 후에 QNA ANSWER 및 관련 데이터가 삭제 되었는지 확인 했습니다.

## 상의드릴 부분
QnaAnswerService.java deleteQnaAnswer 함수에서  상의 드릴 부분이 게시글 삭제 했을때 상의 드릴 부분과 동일합니다!

## 희망 리뷰 완료 일 (Expected due date)
2023.04.28
