### PR TITLE
[Feat-additionalDeleteWithdrawMember] 회원 탈퇴 시 알림 정보, 깃헙 정보도 함께 삭제

### DIFF
--- a/core/src/main/java/zerobase/bud/repository/GithubInfoRepository.java
+++ b/core/src/main/java/zerobase/bud/repository/GithubInfoRepository.java
@@ -2,6 +2,9 @@ package zerobase.bud.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.domain.GithubInfo;
 
@@ -10,5 +13,7 @@ public interface GithubInfoRepository extends JpaRepository<GithubInfo, Long> {
 
     Optional<GithubInfo> findByUserId(String userId);
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query(value = "delete from github_info where member_id=:memberId", nativeQuery = true)
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/core/src/main/java/zerobase/bud/repository/GithubInfoRepository.java
+++ b/core/src/main/java/zerobase/bud/repository/GithubInfoRepository.java
@@ -9,4 +9,6 @@ import zerobase.bud.domain.GithubInfo;
 public interface GithubInfoRepository extends JpaRepository<GithubInfo, Long> {
 
     Optional<GithubInfo> findByUserId(String userId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/user-api/src/main/java/zerobase/bud/member/service/MemberService.java
+++ b/user-api/src/main/java/zerobase/bud/member/service/MemberService.java
@@ -14,6 +14,8 @@ import zerobase.bud.awsS3.AwsS3Api;
 import zerobase.bud.common.exception.BudException;
 import zerobase.bud.common.type.ErrorCode;
 import zerobase.bud.domain.Member;
+import zerobase.bud.notification.repository.NotificationInfoRepository;
+import zerobase.bud.repository.GithubInfoRepository;
 import zerobase.bud.repository.MemberRepository;
 import zerobase.bud.user.repository.FollowRepository;
 
@@ -32,6 +34,10 @@ import static zerobase.bud.util.Constants.PROFILES;
 public class MemberService implements UserDetailsService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+
+    private final NotificationInfoRepository notificationInfoRepository;
+
+    private final GithubInfoRepository githubInfoRepository;
 
     private final AwsS3Api awsS3Api;
 
@@ -88,6 +94,10 @@ public class MemberService implements UserDetailsService {
 
         followRepository.deleteAllByTarget(member);
         followRepository.deleteAllByMember(member);
+
+        notificationInfoRepository.deleteByMemberId(member.getId());
+
+        githubInfoRepository.deleteByMemberId(member.getId());
 
         do {
             uuid = UUID.randomUUID().toString().substring(0, 8);

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
@@ -10,4 +10,6 @@ public interface NotificationInfoRepository extends
     JpaRepository<NotificationInfo, Long> {
 
     Optional<NotificationInfo> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
+++ b/user-api/src/main/java/zerobase/bud/notification/repository/NotificationInfoRepository.java
@@ -1,7 +1,10 @@
 package zerobase.bud.notification.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import zerobase.bud.notification.domain.NotificationInfo;
 
@@ -11,5 +14,7 @@ public interface NotificationInfoRepository extends
 
     Optional<NotificationInfo> findByMemberId(Long memberId);
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query(value = "delete from notification_info where member_id=:memberId", nativeQuery = true)
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 변경 사항
   - 회원 탈퇴 시 알림 정보, 깃헙 정보도 함께 삭제하는 로직 추가

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 04. 28. Fri`
