### PR TITLE
댓글 생성, 수정, 대댓글 생성 관련 테스트 코드 작성

### DIFF
--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -806,7 +806,7 @@ include::{snippets}/qna-answer-controller-test/success_cancel-qna-answer-pin/htt
 |qnaAnswerPinId|Number|Y|path variable, QnA답글 핀의 Id
 |===
 
-=== 27. 댓글 생성
+=== 28. 댓글 생성
 .request
 include::{snippets}/post-controller-test/success-create-comment/http-request.adoc[]
 
@@ -819,7 +819,7 @@ include::{snippets}/post-controller-test/success-create-comment/http-request.ado
 .response
 include::{snippets}/post-controller-test/success-create-comment/http-response.adoc[]
 
-=== 28. 대댓글 생성
+=== 29. 대댓글 생성
 .request
 include::{snippets}/post-controller-test/success-create-recomment/http-request.adoc[]
 
@@ -833,7 +833,7 @@ include::{snippets}/post-controller-test/success-create-recomment/http-request.a
 include::{snippets}/post-controller-test/success-create-recomment/http-response.adoc[]
 
 
-=== 29. 댓글 수정
+=== 30. 댓글 수정
 .request
 include::{snippets}/post-controller-test/success-modify-comment/http-request.adoc[]
 
@@ -845,6 +845,47 @@ include::{snippets}/post-controller-test/success-modify-comment/http-request.ado
 
 .response
 include::{snippets}/post-controller-test/success-modify-comment/http-response.adoc[]
+
+
+=== 31. Q&A 댓글 생성
+.request
+include::{snippets}/qna-answer-controller-test/success-create-comment/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|postId|Number|Y|게시글 아이디, path variable
+|===
+
+.response
+include::{snippets}/qna-answer-controller-test/success-create-comment/http-response.adoc[]
+
+=== 32. Q&A 대댓글 생성
+.request
+include::{snippets}/qna-answer-controller-test/success-create-recomment/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|commentId|Number|Y|댓글 아이디, path variable
+|===
+
+.response
+include::{snippets}/qna-answer-controller-test/success-create-recomment/http-response.adoc[]
+
+
+=== 33. Q&A 댓글 수정
+.request
+include::{snippets}/qna-answer-controller-test/success-modify-comment/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|commentId|Number|Y|댓글 아이디, path variable
+|===
+
+.response
+include::{snippets}/qna-answer-controller-test/success-modify-comment/http-response.adoc[]
 
 
 

--- a/user-api/src/docs/asciidoc/index.adoc
+++ b/user-api/src/docs/asciidoc/index.adoc
@@ -814,11 +814,39 @@ include::{snippets}/post-controller-test/success-create-comment/http-request.ado
 |===
 |필드명|타입|필수여부|설명
 |postId|Number|Y|게시글 아이디, path variable
-|content|
 |===
 
 .response
-include::{snippets}/post-controller-test/success-delete-comment/http-response.adoc[]
+include::{snippets}/post-controller-test/success-create-comment/http-response.adoc[]
+
+=== 28. 대댓글 생성
+.request
+include::{snippets}/post-controller-test/success-create-recomment/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|commentId|Number|Y|댓글 아이디, path variable
+|===
+
+.response
+include::{snippets}/post-controller-test/success-create-recomment/http-response.adoc[]
+
+
+=== 29. 댓글 수정
+.request
+include::{snippets}/post-controller-test/success-modify-comment/http-request.adoc[]
+
+.request field
+|===
+|필드명|타입|필수여부|설명
+|commentId|Number|Y|댓글 아이디, path variable
+|===
+
+.response
+include::{snippets}/post-controller-test/success-modify-comment/http-response.adoc[]
+
+
 
 == 유저 API
 === 1. 유저 팔로우 / 팔로우 취소

--- a/user-api/src/main/java/zerobase/bud/comment/repository/CommentRepository.java
+++ b/user-api/src/main/java/zerobase/bud/comment/repository/CommentRepository.java
@@ -17,4 +17,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Slice<Comment> findByPostAndParentIsNullAndIdIsNotAndCommentStatus(Post post, Long pinCommentId, CommentStatus commentStatus, Pageable pageable);
 
+    int countByPost(Post post);
 }

--- a/user-api/src/main/java/zerobase/bud/comment/repository/CommentRepository.java
+++ b/user-api/src/main/java/zerobase/bud/comment/repository/CommentRepository.java
@@ -17,5 +17,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Slice<Comment> findByPostAndParentIsNullAndIdIsNotAndCommentStatus(Post post, Long pinCommentId, CommentStatus commentStatus, Pageable pageable);
 
-    int countByPost(Post post);
+    int countByParent(Comment comment);
 }

--- a/user-api/src/main/java/zerobase/bud/comment/repository/QnaAnswerCommentRepository.java
+++ b/user-api/src/main/java/zerobase/bud/comment/repository/QnaAnswerCommentRepository.java
@@ -16,4 +16,6 @@ public interface QnaAnswerCommentRepository extends JpaRepository<QnaAnswerComme
 
     Slice<QnaAnswerComment> findByQnaAnswerAndParentIsNullAndIdIsNotAndQnaAnswerCommentStatus(QnaAnswer qnaAnswer, Long pinCommentId, QnaAnswerCommentStatus qnaAnswerCommentStatus, Pageable pageable);
 
+    int countByQnaAnswer(QnaAnswer answer);
+
 }

--- a/user-api/src/main/java/zerobase/bud/comment/repository/QnaAnswerCommentRepository.java
+++ b/user-api/src/main/java/zerobase/bud/comment/repository/QnaAnswerCommentRepository.java
@@ -16,6 +16,6 @@ public interface QnaAnswerCommentRepository extends JpaRepository<QnaAnswerComme
 
     Slice<QnaAnswerComment> findByQnaAnswerAndParentIsNullAndIdIsNotAndQnaAnswerCommentStatus(QnaAnswer qnaAnswer, Long pinCommentId, QnaAnswerCommentStatus qnaAnswerCommentStatus, Pageable pageable);
 
-    int countByQnaAnswer(QnaAnswer answer);
+    int countByParent(QnaAnswerComment comment);
 
 }

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -226,7 +226,7 @@ public class CommentService {
         }
 
         Post post = comment.getPost();
-        post.minusCommentCount(commentRepository.countByParent(comment)+1);
+        post.minusCommentCount(comment.getReComments().size()+1);
         postRepository.save(post);
         commentRepository.delete(comment);
 

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -225,6 +225,10 @@ public class CommentService {
             throw new BudException(ErrorCode.NOT_COMMENT_OWNER);
         }
 
+        Post post = comment.getPost();
+        post.minusCommentCount();
+
+        postRepository.save(post);
         commentRepository.delete(comment);
 
         return commentId;

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -1,10 +1,5 @@
 package zerobase.bud.comment.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +28,12 @@ import zerobase.bud.post.repository.PostRepository;
 import zerobase.bud.post.type.PostStatus;
 import zerobase.bud.post.type.PostType;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -52,19 +53,19 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BudException(ErrorCode.NOT_FOUND_POST));
 
-        Comment comment = Comment.builder()
+
+        post.plusCommentCount();
+
+        postRepository.save(post);
+
+        Comment comment = commentRepository.save(Comment.builder()
                 .post(post)
                 .member(member)
                 .content(content)
                 .likeCount(0)
                 .parent(null)
                 .commentStatus(CommentStatus.ACTIVE)
-                .build();
-
-        post.setCommentCount(post.getCommentCount() + 1);
-
-        commentRepository.save(comment);
-        postRepository.save(post);
+                .build());
 
         eventPublisher.publishEvent(new CreateCommentEvent(member, post));
 
@@ -81,8 +82,7 @@ public class CommentService {
         }
 
         comment.setContent(content);
-        commentRepository.save(comment);
-        return CommentDto.of(comment);
+        return CommentDto.of(commentRepository.save(comment));
     }
 
     @Transactional
@@ -91,22 +91,18 @@ public class CommentService {
                 .orElseThrow(() -> new BudException(ErrorCode.COMMENT_NOT_FOUND));
 
         Post post = parentComment.getPost();
-        post.setCommentCount(post.getCommentCount() + 1);
+        post.plusCommentCount();
 
-        Comment comment = Comment.builder()
+        postRepository.save(post);
+
+        Comment comment = commentRepository.save(Comment.builder()
                 .post(post)
                 .member(member)
                 .content(content)
                 .likeCount(0)
                 .parent(parentComment)
                 .commentStatus(CommentStatus.ACTIVE)
-                .build();
-
-        parentComment.getReComments().add(comment);
-
-        commentRepository.save(parentComment);
-        commentRepository.save(comment);
-        postRepository.save(post);
+                .build());
 
         eventPublisher.publishEvent(new CreateRecommentEvent(member, parentComment));
 

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -226,8 +226,7 @@ public class CommentService {
         }
 
         Post post = comment.getPost();
-        post.setCommentCount(commentRepository.countByPost(post));
-
+        post.minusCommentCount(commentRepository.countByParent(comment)+1);
         postRepository.save(post);
         commentRepository.delete(comment);
 

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -226,7 +226,7 @@ public class CommentService {
         }
 
         Post post = comment.getPost();
-        post.minusCommentCount();
+        post.setCommentCount(commentRepository.countByPost(post));
 
         postRepository.save(post);
         commentRepository.delete(comment);

--- a/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/CommentService.java
@@ -77,7 +77,7 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new BudException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if (!comment.getMember().equals(member)) {
+        if (!Objects.equals(comment.getMember().getId(), member.getId())) {
             throw new BudException(ErrorCode.NOT_COMMENT_OWNER);
         }
 

--- a/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
@@ -163,7 +163,7 @@ public class QnaAnswerCommentService {
         }
 
         QnaAnswer qnaAnswer = qnaAnswerComment.getQnaAnswer();
-        qnaAnswer.setCommentCount(qnaAnswerCommentRepository.countByQnaAnswer(qnaAnswer));
+        qnaAnswer.minusCommentCount(qnaAnswerCommentRepository.countByParent(qnaAnswerComment)+1);
 
         qnaAnswerRepository.save(qnaAnswer);
         qnaAnswerCommentRepository.delete(qnaAnswerComment);

--- a/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
@@ -199,8 +199,7 @@ public class QnaAnswerCommentService {
         QnaAnswerComment qnaAnswerComment = qnaAnswerCommentRepository.findById(commentId)
                 .orElseThrow(() -> new BudException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if (!Objects.equals(qnaAnswerComment.getMember()
-                .getId(), member.getId())) {
+        if (!Objects.equals(qnaAnswerComment.getMember().getId(), member.getId())) {
             throw new BudException(ErrorCode.NOT_COMMENT_OWNER);
         }
 

--- a/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
@@ -163,7 +163,7 @@ public class QnaAnswerCommentService {
         }
 
         QnaAnswer qnaAnswer = qnaAnswerComment.getQnaAnswer();
-        qnaAnswer.commentCountdown();
+        qnaAnswer.setCommentCount(qnaAnswerCommentRepository.countByQnaAnswer(qnaAnswer));
 
         qnaAnswerRepository.save(qnaAnswer);
         qnaAnswerCommentRepository.delete(qnaAnswerComment);

--- a/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
+++ b/user-api/src/main/java/zerobase/bud/comment/service/QnaAnswerCommentService.java
@@ -163,7 +163,7 @@ public class QnaAnswerCommentService {
         }
 
         QnaAnswer qnaAnswer = qnaAnswerComment.getQnaAnswer();
-        qnaAnswer.minusCommentCount(qnaAnswerCommentRepository.countByParent(qnaAnswerComment)+1);
+        qnaAnswer.minusCommentCount(qnaAnswerComment.getReComments().size()+1);
 
         qnaAnswerRepository.save(qnaAnswer);
         qnaAnswerCommentRepository.delete(qnaAnswerComment);

--- a/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
+++ b/user-api/src/main/java/zerobase/bud/post/controller/PostController.java
@@ -1,7 +1,5 @@
 package zerobase.bud.post.controller;
 
-import static zerobase.bud.post.util.Constants.*;
-
 import com.querydsl.core.types.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +18,8 @@ import zerobase.bud.post.type.PostType;
 
 import javax.validation.Valid;
 import java.util.List;
+
+import static zerobase.bud.post.util.Constants.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -104,23 +104,23 @@ public class PostController {
 
     @PostMapping("/{postId}/comments")
     public ResponseEntity<CommentDto> createComment(@PathVariable Long postId,
-                                                @AuthenticationPrincipal Member member,
-                                                @RequestBody String content) {
-        return ResponseEntity.ok(commentService.createComment(postId, member, content));
+                                                    @AuthenticationPrincipal Member member,
+                                                    @Valid @RequestBody CreateComment.Request request) {
+        return ResponseEntity.ok(commentService.createComment(postId, member, request.getContent()));
     }
 
     @PutMapping("/comments/{commentId}/modify")
     public ResponseEntity<CommentDto> modifyComment(@PathVariable Long commentId,
-                                                @AuthenticationPrincipal Member member,
-                                                @RequestBody String content) {
-        return ResponseEntity.ok(commentService.modifyComment(commentId, member, content));
+                                                    @AuthenticationPrincipal Member member,
+                                                    @Valid @RequestBody CreateComment.Request request) {
+        return ResponseEntity.ok(commentService.modifyComment(commentId, member, request.getContent()));
     }
 
     @PostMapping("/comments/{commentId}")
     public ResponseEntity<RecommentDto> createRecomment(@PathVariable Long commentId,
                                                         @AuthenticationPrincipal Member member,
-                                                        @RequestBody String content) {
-        return ResponseEntity.ok(commentService.createRecomment(commentId, member, content));
+                                                        @Valid @RequestBody CreateComment.Request request) {
+        return ResponseEntity.ok(commentService.createRecomment(commentId, member, request.getContent()));
     }
 
     @PostMapping("/comments/{commentId}/like")
@@ -152,7 +152,7 @@ public class PostController {
 
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Long> deleteComment(@PathVariable Long commentId,
-                                                 @AuthenticationPrincipal Member member) {
+                                              @AuthenticationPrincipal Member member) {
         return ResponseEntity.ok(commentService.delete(commentId, member));
     }
 }

--- a/user-api/src/main/java/zerobase/bud/post/domain/Post.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/Post.java
@@ -89,8 +89,8 @@ public class Post extends BaseEntity {
         this.commentCount += 1;
     }
 
-    public void minusCommentCount() {
-        this.commentCount -= 1;
+    public void minusCommentCount(int numberOfComments) {
+        this.commentCount -= numberOfComments;
     }
 
     public void scrapCountUp() {

--- a/user-api/src/main/java/zerobase/bud/post/domain/Post.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/Post.java
@@ -89,6 +89,10 @@ public class Post extends BaseEntity {
         this.commentCount += 1;
     }
 
+    public void minusCommentCount() {
+        this.commentCount -= 1;
+    }
+
     public void scrapCountUp() {
         this.scrapCount++;
     }

--- a/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswer.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswer.java
@@ -83,7 +83,7 @@ public class QnaAnswer extends BaseEntity {
         this.commentCount++;
     }
 
-    public void commentCountdown() {
-        this.commentCount--;
+    public void minusCommentCount(int numberOfComments) {
+        this.commentCount -= numberOfComments;
     }
 }

--- a/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswer.java
+++ b/user-api/src/main/java/zerobase/bud/post/domain/QnaAnswer.java
@@ -78,4 +78,12 @@ public class QnaAnswer extends BaseEntity {
     public void likeCountDown() {
         this.likeCount--;
     }
+
+    public void commentCountUp() {
+        this.commentCount++;
+    }
+
+    public void commentCountdown() {
+        this.commentCount--;
+    }
 }

--- a/user-api/src/main/java/zerobase/bud/post/dto/CreateComment.java
+++ b/user-api/src/main/java/zerobase/bud/post/dto/CreateComment.java
@@ -1,0 +1,22 @@
+package zerobase.bud.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+public class CreateComment {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        @NotBlank
+        private String content;
+
+    }
+
+}

--- a/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
@@ -730,8 +730,15 @@ class CommentServiceTest {
     @DisplayName("댓글 삭제 성공")
     void successDeleteWhenCommentNotFoundTest() {
         //given
+        Post post = Post.builder()
+                .id(1L)
+                .commentCount(1)
+                .likeCount(1)
+                .build();
+
         Comment comment = Comment.builder()
                 .member(member)
+                .post(post)
                 .createdAt(LocalDateTime.now())
                 .id(3L)
                 .build();
@@ -739,9 +746,12 @@ class CommentServiceTest {
         given(commentRepository.findByIdAndCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
         //when
+        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
         Long result = commentService.delete(123L, member);
         //then
         verify(commentRepository, times(1)).delete(any());
+        verify(postRepository, times(1)).save(postArgumentCaptor.capture());
+        assertEquals(0, postArgumentCaptor.getValue().getCommentCount());
         assertEquals(result, 123L);
     }
 

--- a/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
@@ -732,7 +732,7 @@ class CommentServiceTest {
         //given
         Post post = Post.builder()
                 .id(1L)
-                .commentCount(1)
+                .commentCount(3)
                 .likeCount(1)
                 .build();
 
@@ -746,8 +746,8 @@ class CommentServiceTest {
         given(commentRepository.findByIdAndCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
 
-        given(commentRepository.countByPost(any()))
-                .willReturn(2);
+        given(commentRepository.countByParent(any()))
+                .willReturn(0);
         //when
         ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
         Long result = commentService.delete(123L, member);

--- a/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
@@ -745,13 +745,16 @@ class CommentServiceTest {
 
         given(commentRepository.findByIdAndCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
+
+        given(commentRepository.countByPost(any()))
+                .willReturn(2);
         //when
         ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
         Long result = commentService.delete(123L, member);
         //then
         verify(commentRepository, times(1)).delete(any());
         verify(postRepository, times(1)).save(postArgumentCaptor.capture());
-        assertEquals(0, postArgumentCaptor.getValue().getCommentCount());
+        assertEquals(2, postArgumentCaptor.getValue().getCommentCount());
         assertEquals(result, 123L);
     }
 

--- a/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
@@ -746,8 +746,6 @@ class CommentServiceTest {
         given(commentRepository.findByIdAndCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
 
-        given(commentRepository.countByParent(any()))
-                .willReturn(0);
         //when
         ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
         Long result = commentService.delete(123L, member);

--- a/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/CommentServiceTest.java
@@ -1,17 +1,5 @@
 package zerobase.bud.comment.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static zerobase.bud.post.type.PostStatus.ACTIVE;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,9 +23,23 @@ import zerobase.bud.notification.event.like.AddLikeCommentEvent;
 import zerobase.bud.notification.event.pin.CommentPinEvent;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.dto.CommentDto;
+import zerobase.bud.post.dto.RecommentDto;
 import zerobase.bud.post.repository.PostRepository;
 import zerobase.bud.post.type.PostType;
 import zerobase.bud.type.MemberStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static zerobase.bud.post.type.PostStatus.ACTIVE;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -69,6 +71,180 @@ class CommentServiceTest {
             .build();
 
     @Test
+    @DisplayName("댓글 생성 성공")
+    void successCreateCommentTest() {
+        //given
+        given(postRepository.findById(anyLong()))
+                .willReturn(Optional.of(Post.builder()
+                        .title("title")
+                        .content("content")
+                        .postStatus(ACTIVE)
+                        .commentCount(0)
+                        .postType(PostType.FEED)
+                        .build()));
+
+        given(commentRepository.save(any()))
+                .willReturn(Comment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("하이하이")
+                        .parent(null)
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+        //when
+        ArgumentCaptor<Comment> commentArgumentCaptor = ArgumentCaptor.forClass(Comment.class);
+        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
+        CommentDto dto = commentService.createComment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(commentRepository, times(1)).save(commentArgumentCaptor.capture());
+        verify(postRepository, times(1)).save(postArgumentCaptor.capture());
+        assertEquals("이것은 댓글입니다", commentArgumentCaptor.getValue().getContent());
+        assertEquals(0, dto.getNumberOfLikes());
+        assertEquals(1, postArgumentCaptor.getValue().getCommentCount());
+        assertEquals(1L, dto.getMemberId());
+    }
+
+    @Test
+    @DisplayName("댓글 생성 실패 - 해당 포스트가 없음")
+    void failCreateCommentTestWhenNotFoundPost() {
+        //given
+        given(postRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> commentService.createComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_POST, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void successModifyComment() {
+        //given
+        Comment comment = Comment.builder()
+                .member(member)
+                .content("수정전텍스트")
+                .likeCount(1)
+                .id(3L)
+                .build();
+
+        given(commentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+
+        given(commentRepository.save(any()))
+                .willReturn(Comment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("수정후 텍스트")
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+        //when
+        ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+        CommentDto dto = commentService.modifyComment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(commentRepository, times(1)).save(captor.capture());
+        assertEquals("수정후 텍스트", dto.getContent());
+        assertEquals("이것은 댓글입니다", captor.getValue().getContent());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 해당 댓글이 없음")
+    void failModifyCommentWhenCommentNotFoundTest() {
+        //given
+        given(commentRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> commentService.modifyComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 요청한 유저가 댓글 작성자가 아님")
+    void failModifyCommentWhenNotCommentOwnerTest() {
+        //given
+        Member commentWriter = Member.builder()
+                .id(2L)
+                .createdAt(LocalDateTime.now())
+                .status(MemberStatus.VERIFIED)
+                .profileImg("aaaaaa.jpg")
+                .nickname("비가와")
+                .job("풀스택개발자")
+                .build();
+
+        Comment comment = Comment.builder()
+                .member(commentWriter)
+                .content("수정전텍스트")
+                .likeCount(1)
+                .id(3L)
+                .build();
+
+        given(commentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> commentService.modifyComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.NOT_COMMENT_OWNER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 성공")
+    void successCreateRecommentTest() {
+        //given
+        Post post = Post.builder()
+                .title("title")
+                .content("content")
+                .postStatus(ACTIVE)
+                .commentCount(0)
+                .postType(PostType.FEED)
+                .build();
+
+        Comment parentComment = Comment.builder()
+                .id(2L)
+                .post(post)
+                .build();
+
+        given(commentRepository.findById(anyLong()))
+                .willReturn(Optional.of(parentComment));
+
+        given(commentRepository.save(any()))
+                .willReturn(Comment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("하이하이")
+                        .parent(parentComment)
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+
+        //when
+        ArgumentCaptor<Comment> commentArgumentCaptor = ArgumentCaptor.forClass(Comment.class);
+        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
+        RecommentDto dto = commentService.createRecomment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(commentRepository, times(1)).save(commentArgumentCaptor.capture());
+        verify(postRepository, times(1)).save(postArgumentCaptor.capture());
+        assertEquals("이것은 댓글입니다", commentArgumentCaptor.getValue().getContent());
+        assertEquals(0, dto.getNumberOfLikes());
+        assertEquals(1, postArgumentCaptor.getValue().getCommentCount());
+        assertEquals(1L, dto.getMemberId());
+    }
+
+    @Test
+    @DisplayName("대댓글 실패 - 원댓글이 없음")
+    void failCreateRecommentWhenCommentNotFoundPostTest() {
+        //given
+        given(commentRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> commentService.createRecomment(123L, member, "이것은 대댓글입니다"));
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
     @DisplayName("좋아요 성공")
     void successCommentLikeTest() {
         //given
@@ -82,12 +258,12 @@ class CommentServiceTest {
                 .build();
 
         Post post = Post.builder()
-            .member(writer)
-            .title("title")
-            .content("content")
-            .postStatus(ACTIVE)
-            .postType(PostType.FEED)
-            .build();
+                .member(writer)
+                .title("title")
+                .content("content")
+                .postStatus(ACTIVE)
+                .postType(PostType.FEED)
+                .build();
 
         Comment comment = Comment.builder()
                 .member(writer)

--- a/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
@@ -749,15 +749,13 @@ class QnaAnswerCommentServiceTest {
         given(qnaAnswerCommentRepository.findByIdAndQnaAnswerCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
 
-        given(qnaAnswerCommentRepository.countByParent(any()))
-                .willReturn(2);
         //when
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(QnaAnswer.class);
         Long result = qnaAnswerCommentService.delete(123L, member);
         //then
         verify(qnaAnswerCommentRepository, times(1)).delete(any());
         verify(qnaAnswerRepository, times(1)).save(captor.capture());
-        assertEquals(0, captor.getValue().getCommentCount());
+        assertEquals(2, captor.getValue().getCommentCount());
         assertEquals(result, 123L);
     }
 

--- a/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
@@ -736,7 +736,7 @@ class QnaAnswerCommentServiceTest {
 
         QnaAnswer qnaAnswer = QnaAnswer.builder()
                 .id(1L)
-                .commentCount(1)
+                .commentCount(3)
                 .build();
 
         QnaAnswerComment comment = QnaAnswerComment.builder()
@@ -749,8 +749,8 @@ class QnaAnswerCommentServiceTest {
         given(qnaAnswerCommentRepository.findByIdAndQnaAnswerCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
 
-        given(qnaAnswerCommentRepository.countByQnaAnswer(any()))
-                .willReturn(0);
+        given(qnaAnswerCommentRepository.countByParent(any()))
+                .willReturn(2);
         //when
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(QnaAnswer.class);
         Long result = qnaAnswerCommentService.delete(123L, member);

--- a/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
@@ -1,17 +1,5 @@
 package zerobase.bud.comment.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static zerobase.bud.post.type.PostStatus.ACTIVE;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import zerobase.bud.comment.domain.Comment;
 import zerobase.bud.comment.domain.QnaAnswerComment;
 import zerobase.bud.comment.domain.QnaAnswerCommentLike;
 import zerobase.bud.comment.domain.QnaAnswerCommentPin;
@@ -35,10 +24,25 @@ import zerobase.bud.notification.event.like.AddLikeQnaAnswerCommentEvent;
 import zerobase.bud.notification.event.pin.QnaAnswerCommentPinEvent;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.domain.QnaAnswer;
+import zerobase.bud.post.dto.CommentDto;
 import zerobase.bud.post.dto.QnaAnswerCommentDto;
+import zerobase.bud.post.dto.QnaAnswerRecommentDto;
 import zerobase.bud.post.repository.QnaAnswerRepository;
 import zerobase.bud.post.type.PostType;
 import zerobase.bud.type.MemberStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static zerobase.bud.post.type.PostStatus.ACTIVE;
 
 @ExtendWith(MockitoExtension.class)
 class QnaAnswerCommentServiceTest {
@@ -70,6 +74,174 @@ class QnaAnswerCommentServiceTest {
             .build();
 
     @Test
+    @DisplayName("댓글 생성 성공")
+    void successCreateCommentTest() {
+        //given
+        given(qnaAnswerRepository.findById(anyLong()))
+                .willReturn(Optional.of(QnaAnswer.builder()
+                        .commentCount(0)
+                        .content("이러이러한 답변을 합니다")
+                        .build()));
+
+        given(qnaAnswerCommentRepository.save(any()))
+                .willReturn(QnaAnswerComment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("하이하이")
+                        .parent(null)
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+        //when
+        ArgumentCaptor<QnaAnswerComment> commentArgumentCaptor = ArgumentCaptor.forClass(QnaAnswerComment.class);
+        ArgumentCaptor<QnaAnswer> qnaAnswerArgumentCaptor = ArgumentCaptor.forClass(QnaAnswer.class);
+        QnaAnswerCommentDto dto = qnaAnswerCommentService.createComment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(qnaAnswerCommentRepository, times(1)).save(commentArgumentCaptor.capture());
+        verify(qnaAnswerRepository, times(1)).save(qnaAnswerArgumentCaptor.capture());
+        assertEquals("이것은 댓글입니다", commentArgumentCaptor.getValue().getContent());
+        assertEquals(0, dto.getNumberOfLikes());
+        assertEquals(1, qnaAnswerArgumentCaptor.getValue().getCommentCount());
+        assertEquals(1L, dto.getMemberId());
+    }
+
+    @Test
+    @DisplayName("댓글 생성 실패 - 해당 포스트가 없음")
+    void failCreateCommentTestWhenNotFoundPost() {
+        //given
+        given(qnaAnswerRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> qnaAnswerCommentService.createComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_QNA_ANSWER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void successModifyComment() {
+        //given
+        QnaAnswerComment comment = QnaAnswerComment.builder()
+                .member(member)
+                .content("수정전텍스트")
+                .likeCount(1)
+                .id(3L)
+                .build();
+
+        given(qnaAnswerCommentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+
+        given(qnaAnswerCommentRepository.save(any()))
+                .willReturn(QnaAnswerComment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("수정후 텍스트")
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+        //when
+        ArgumentCaptor<QnaAnswerComment> captor = ArgumentCaptor.forClass(QnaAnswerComment.class);
+
+        QnaAnswerCommentDto dto = qnaAnswerCommentService.modifyComment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(qnaAnswerCommentRepository, times(1)).save(captor.capture());
+        assertEquals("수정후 텍스트", dto.getContent());
+        assertEquals("이것은 댓글입니다", captor.getValue().getContent());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 해당 댓글이 없음")
+    void failModifyCommentWhenCommentNotFoundTest() {
+        //given
+        given(qnaAnswerCommentRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> qnaAnswerCommentService.modifyComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패 - 요청한 유저가 댓글 작성자가 아님")
+    void failModifyCommentWhenNotCommentOwnerTest() {
+        //given
+        Member commentWriter = Member.builder()
+                .id(2L)
+                .createdAt(LocalDateTime.now())
+                .status(MemberStatus.VERIFIED)
+                .profileImg("aaaaaa.jpg")
+                .nickname("비가와")
+                .job("풀스택개발자")
+                .build();
+
+        QnaAnswerComment comment = QnaAnswerComment.builder()
+                .member(commentWriter)
+                .content("수정전텍스트")
+                .likeCount(1)
+                .id(3L)
+                .build();
+
+        given(qnaAnswerCommentRepository.findById(anyLong()))
+                .willReturn(Optional.of(comment));
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> qnaAnswerCommentService.modifyComment(123L, member, "이것은 댓글입니다"));
+        //then
+        assertEquals(ErrorCode.NOT_COMMENT_OWNER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 성공")
+    void successCreateRecommentTest() {
+        //given
+        QnaAnswer qnaAnswer = QnaAnswer.builder()
+                .commentCount(0)
+                .build();
+
+        QnaAnswerComment parentComment = QnaAnswerComment.builder()
+                .id(2L)
+                .qnaAnswer(qnaAnswer)
+                .build();
+
+        given(qnaAnswerCommentRepository.findById(anyLong()))
+                .willReturn(Optional.of(parentComment));
+
+        given(qnaAnswerCommentRepository.save(any()))
+                .willReturn(QnaAnswerComment.builder()
+                        .member(member)
+                        .likeCount(0)
+                        .content("하이하이")
+                        .parent(parentComment)
+                        .createdAt(LocalDateTime.now())
+                        .id(3L)
+                        .build());
+
+        //when
+        ArgumentCaptor<QnaAnswerComment> qnaAnswerCommentArgumentCaptor = ArgumentCaptor.forClass(QnaAnswerComment.class);
+        ArgumentCaptor<QnaAnswer> qnaAnswerArgumentCaptor = ArgumentCaptor.forClass(QnaAnswer.class);
+        QnaAnswerRecommentDto dto = qnaAnswerCommentService.createRecomment(123L, member, "이것은 댓글입니다");
+        //then
+        verify(qnaAnswerCommentRepository, times(1)).save(qnaAnswerCommentArgumentCaptor.capture());
+        verify(qnaAnswerRepository, times(1)).save(qnaAnswerArgumentCaptor.capture());
+        assertEquals("이것은 댓글입니다", qnaAnswerCommentArgumentCaptor.getValue().getContent());
+        assertEquals(0, dto.getNumberOfLikes());
+        assertEquals(1, qnaAnswerArgumentCaptor.getValue().getCommentCount());
+        assertEquals(1L, dto.getMemberId());
+    }
+
+    @Test
+    @DisplayName("대댓글 실패 - 원댓글이 없음")
+    void failCreateRecommentWhenCommentNotFoundPostTest() {
+        //given
+        given(qnaAnswerCommentRepository.findById(anyLong())).willReturn(Optional.empty());
+        //when
+        BudException exception = assertThrows(BudException.class,
+                () -> qnaAnswerCommentService.createRecomment(123L, member, "이것은 대댓글입니다"));
+        //then
+        assertEquals(ErrorCode.COMMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
     @DisplayName("qna 댓글 좋아요 성공")
     void successCommentLikeTest() {
         //given
@@ -83,17 +255,17 @@ class QnaAnswerCommentServiceTest {
                 .build();
 
         Post post = Post.builder()
-            .id(1L)
-            .member(writer)
-            .title("title")
-            .content("content")
-            .postStatus(ACTIVE)
-            .postType(PostType.FEED)
-            .build();
+                .id(1L)
+                .member(writer)
+                .title("title")
+                .content("content")
+                .postStatus(ACTIVE)
+                .postType(PostType.FEED)
+                .build();
 
         QnaAnswer qnaAnswer = QnaAnswer.builder()
-            .post(post)
-            .build();
+                .post(post)
+                .build();
 
         QnaAnswerComment qnaAnswerComment = QnaAnswerComment.builder()
                 .member(writer)
@@ -561,8 +733,15 @@ class QnaAnswerCommentServiceTest {
     @DisplayName("qna 댓글 삭제 성공")
     void successDeleteWhenCommentNotFoundTest() {
         //given
+
+        QnaAnswer qnaAnswer = QnaAnswer.builder()
+                .id(1L)
+                .commentCount(1)
+                .build();
+
         QnaAnswerComment comment = QnaAnswerComment.builder()
                 .member(member)
+                .qnaAnswer(qnaAnswer)
                 .createdAt(LocalDateTime.now())
                 .id(3L)
                 .build();
@@ -570,9 +749,12 @@ class QnaAnswerCommentServiceTest {
         given(qnaAnswerCommentRepository.findByIdAndQnaAnswerCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
         //when
+        ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(QnaAnswer.class);
         Long result = qnaAnswerCommentService.delete(123L, member);
         //then
         verify(qnaAnswerCommentRepository, times(1)).delete(any());
+        verify(qnaAnswerRepository, times(1)).save(captor.capture());
+        assertEquals(0, captor.getValue().getCommentCount());
         assertEquals(result, 123L);
     }
 

--- a/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
+++ b/user-api/src/test/java/zerobase/bud/comment/service/QnaAnswerCommentServiceTest.java
@@ -748,6 +748,9 @@ class QnaAnswerCommentServiceTest {
 
         given(qnaAnswerCommentRepository.findByIdAndQnaAnswerCommentStatus(anyLong(), any()))
                 .willReturn(Optional.of(comment));
+
+        given(qnaAnswerCommentRepository.countByQnaAnswer(any()))
+                .willReturn(0);
         //when
         ArgumentCaptor<QnaAnswer> captor = ArgumentCaptor.forClass(QnaAnswer.class);
         Long result = qnaAnswerCommentService.delete(123L, member);

--- a/user-api/src/test/java/zerobase/bud/post/controller/PostControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/PostControllerTest.java
@@ -27,6 +27,8 @@ import zerobase.bud.comment.service.CommentService;
 import zerobase.bud.jwt.TokenProvider;
 import zerobase.bud.post.domain.Post;
 import zerobase.bud.post.dto.CommentDto;
+import zerobase.bud.post.dto.CreateComment;
+import zerobase.bud.post.dto.RecommentDto;
 import zerobase.bud.post.dto.SearchPost;
 import zerobase.bud.post.service.PostService;
 import zerobase.bud.post.service.ScrapService;
@@ -50,8 +52,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -386,7 +387,7 @@ class PostControllerTest {
     void success_deletePost() throws Exception {
         //given
         Post post = Post.builder()
-                .id((long)1)
+                .id((long) 1)
                 .title("제목")
                 .content("내용")
                 .commentCount(1)
@@ -514,6 +515,117 @@ class PostControllerTest {
                                 preprocessResponse(prettyPrint())
                         )
                 );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("댓글 생성 성공")
+    void successCreateComment() throws Exception {
+        //given
+        given(commentService.createComment(anyLong(), any(), anyString()))
+                .willReturn(
+                        CommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(post("/posts/{postId}/comments", 23)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("댓글 수정 성공")
+    void successModifyComment() throws Exception {
+        //given
+        given(commentService.modifyComment(anyLong(), any(), anyString()))
+                .willReturn(
+                        CommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(put("/posts/comments/{commentId}/modify", 3)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("대댓글 생성 성공")
+    void successCreateRecomment() throws Exception {
+        //given
+        given(commentService.createRecomment(anyLong(), any(), anyString()))
+                .willReturn(
+                        RecommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(post("/posts/comments/{commentId}", 23)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
     }
 
 
@@ -673,7 +785,7 @@ class PostControllerTest {
                 .willReturn(new SliceImpl<>(dtos));
 
 
-        this.mockMvc.perform(get("/posts/{postId}/comments",1)
+        this.mockMvc.perform(get("/posts/{postId}/comments", 1)
                         .param("page", "0")
                         .param("size", "5")
                         .header(HttpHeaders.AUTHORIZATION, TOKEN)

--- a/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
+++ b/user-api/src/test/java/zerobase/bud/post/controller/QnaAnswerControllerTest.java
@@ -1,8 +1,7 @@
 package zerobase.bud.post.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -15,8 +14,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -54,8 +52,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import zerobase.bud.comment.service.QnaAnswerCommentService;
 import zerobase.bud.jwt.TokenProvider;
-import zerobase.bud.post.dto.QnaAnswerCommentDto;
-import zerobase.bud.post.dto.SearchQnaAnswer;
+import zerobase.bud.post.dto.*;
 import zerobase.bud.post.service.QnaAnswerService;
 import zerobase.bud.post.type.QnaAnswerStatus;
 
@@ -623,5 +620,116 @@ class QnaAnswerControllerTest {
                                 preprocessResponse(prettyPrint())
                         )
                 );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("댓글 생성 성공")
+    void successCreateComment() throws Exception {
+        //given
+        given(qnaAnswerCommentService.createComment(anyLong(), any(), anyString()))
+                .willReturn(
+                        QnaAnswerCommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(post("/posts/qna-answers/{postId}/comments", 23)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("댓글 수정 성공")
+    void successModifyComment() throws Exception {
+        //given
+        given(qnaAnswerCommentService.modifyComment(anyLong(), any(), anyString()))
+                .willReturn(
+                        QnaAnswerCommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(put("/posts/qna-answers/comments/{commentId}/modify", 3)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("대댓글 생성 성공")
+    void successCreateRecomment() throws Exception {
+        //given
+        given(qnaAnswerCommentService.createRecomment(anyLong(), any(), anyString()))
+                .willReturn(
+                        QnaAnswerRecommentDto.builder()
+                                .commentId(2L)
+                                .content("이것은 댓글입니다")
+                                .numberOfLikes(0)
+                                .memberName("아디다스")
+                                .memberProfileUrl("profiles/images.jpg")
+                                .memberId(2L)
+                                .createdAt("0 초전")
+                                .build()
+                );
+        //when
+        //then
+        this.mockMvc.perform(post("/posts/qna-answers/comments/{commentId}", 23)
+                        .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                CreateComment.Request.builder()
+                                        .content("이것은 댓글입니다").build()
+                        ))
+                )
+                .andExpect(status().isOk())
+
+                .andDo(
+                        document("{class-name}/{method-name}",
+                                preprocessRequest(modifyUris().scheme(scheme).host(host).port(port), prettyPrint()),
+                                preprocessResponse(prettyPrint()))
+                );
+
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 댓글 생성, 수정, 대댓글 생성 관련 테스트 코드 작성
- qna 댓글 생성, 수정, 대댓글 생성 관련 테스트 코드 작성
- 캡슐화가 지켜지지 않은 부분 리팩토링
- content String 자체를 RequestBody 로 받았던 부분 RequestBody 추가
   1. valid 하기 위함 2. 기존과 같이 작업하면 파라미터 이상
- 대댓글 생성시 parent 가 가지고 있는 recomment list에 추가하는 작업 필요 없기 때문에 해당 코드 제거
- 생성, 수정시 레파지토리에서 반환한 객체로 dto가 만들어지도록 수정 (생성한 빌더 객체로 반환하면 null point exception 발생)
- 댓글 삭제시 본문 컨텐츠에 댓글 수 차감되게 설정

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)
`2023. 4. 28. Fri`
