### PR TITLE
Feat#219: OAuth 로그인 로직 변경에 따른 LoginService 수정

### DIFF
--- a/core/src/main/java/zerobase/bud/domain/Member.java
+++ b/core/src/main/java/zerobase/bud/domain/Member.java
@@ -63,6 +63,19 @@ public class Member extends BaseEntity implements UserDetails {
         return this;
     }
 
+    public static Member register(String userId, String userCode, String nickname, String token, String profileImg, Level level) {
+        return Member.builder()
+                .userId(userId)
+                .userCode(userCode)
+                .nickname(nickname)
+                .oauthToken(token)
+                .profileImg(profileImg)
+                .level(level)
+                .addInfoYn(false)
+                .status(MemberStatus.VERIFIED)
+                .build();
+    }
+
     public void updateLevel(Level level) {
         this.level = level;
     }

--- a/user-api/src/main/java/zerobase/bud/oauth/controller/LoginController.java
+++ b/user-api/src/main/java/zerobase/bud/oauth/controller/LoginController.java
@@ -9,16 +9,20 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.bud.oauth.service.LoginService;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class LoginController {
     private final LoginService loginService;
     @GetMapping("/token")
     public ResponseEntity<?> requestCode(@RequestParam(value = "code", required = false) String code) {
-        String token = loginService.codeToJwt(code);
-        if(ObjectUtils.isEmpty(token)) return ResponseEntity.ok(null);
+        List<String> tokenInfo = loginService.codeToJwt(code);
+        if(ObjectUtils.isEmpty(tokenInfo.get(0))) return ResponseEntity.ok(null);
 
-        return ResponseEntity.ok().header(HttpHeaders.AUTHORIZATION, token).build();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, tokenInfo.get(0))
+                .header("JWT_USER_INFORMATION", tokenInfo.get(1))
+                .build();
     }
-
 }

--- a/user-api/src/main/java/zerobase/bud/oauth/service/LoginService.java
+++ b/user-api/src/main/java/zerobase/bud/oauth/service/LoginService.java
@@ -3,27 +3,33 @@ package zerobase.bud.oauth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestTemplate;
-import zerobase.bud.common.exception.BudException;
-import zerobase.bud.common.type.ErrorCode;
+import zerobase.bud.awsS3.AwsS3Api;
+import zerobase.bud.domain.GithubInfo;
+import zerobase.bud.domain.Level;
 import zerobase.bud.domain.Member;
 import zerobase.bud.jwt.TokenProvider;
+import zerobase.bud.repository.GithubInfoRepository;
+import zerobase.bud.repository.LevelRepository;
 import zerobase.bud.repository.MemberRepository;
+
+import java.util.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class LoginService {
     private final TokenProvider tokenProvider;
+    private final LevelRepository levelRepository;
     private final MemberRepository memberRepository;
+    private final GithubInfoRepository githubInfoRepository;
+    private final AwsS3Api awsS3Api;
 
     @Value("${spring.security.oauth2.client.registration.github.client-id}")
     String client_id;
@@ -31,23 +37,84 @@ public class LoginService {
     @Value("${spring.security.oauth2.client.registration.github.client-secret}")
     String client_secret;
 
-    public String codeToJwt(String code) {
-        HttpHeaders headers = new HttpHeaders();
-        RestTemplate restTemplate = new RestTemplate();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    @Transactional
+    public List<String> codeToJwt(String code) {
+        HttpHeaders tokenHeaders = new HttpHeaders();
+        RestTemplate tokenTemplate = new RestTemplate();
+        tokenHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("code", code);
-        params.add("client_id", client_id);
-        params.add("client_secret", client_secret);
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<String> response = restTemplate.postForEntity("https://github.com/login/oauth/access_token", request, String.class);
+        MultiValueMap<String, String> tokenParam = new LinkedMultiValueMap<>();
+        tokenParam.add("code", code);
+        tokenParam.add("client_id", client_id);
+        tokenParam.add("client_secret", client_secret);
+        HttpEntity<MultiValueMap<String, String>> oAuthTokenRequest = new HttpEntity<>(tokenParam, tokenHeaders);
+        ResponseEntity<String> tokenResponse = tokenTemplate.postForEntity("https://github.com/login/oauth/access_token", oAuthTokenRequest, String.class);
 
-        if(ObjectUtils.isEmpty(response.getBody()) || !response.getBody().contains("access_token") || response.getBody().contains("error")) return "";
-        String OAuthAccessToken = response.getBody().replace("access_token=", "").replace("&scope=&token_type=bearer", "");
-        log.info("Response: OAuth2 Access Token by Query_Code: " + OAuthAccessToken);
+        if(ObjectUtils.isEmpty(tokenResponse.getBody()) || !tokenResponse.getBody().contains("access_token") || tokenResponse.getBody().contains("error")) return null;
+        String OAuthAccessToken = tokenResponse.getBody().replace("access_token=", "").replace("&scope=&token_type=bearer", "");
 
-        Member member = memberRepository.findByOauthToken(OAuthAccessToken).orElseThrow(() -> new BudException(ErrorCode.INVALID_TOKEN));
-        return "Bearer " + tokenProvider.generateToken(member.getUserId()).getAccessToken();
+        HttpHeaders userHeaders = new HttpHeaders();
+        RestTemplate userTemplate = new RestTemplate();
+        MultiValueMap<String, String> userParam = new LinkedMultiValueMap<>();
+        userHeaders.add(HttpHeaders.AUTHORIZATION,"Bearer " + OAuthAccessToken);
+        HttpEntity<MultiValueMap<String, String>> getUserInfoRequest = new HttpEntity<>(userParam, userHeaders);
+        ResponseEntity<Map> userResponse = userTemplate.exchange("https://api.github.com/user", HttpMethod.GET, getUserInfoRequest, Map.class);
+
+        if(ObjectUtils.isEmpty(userResponse)) return null;
+
+        Member member = saveOrUpdate(userResponse.getBody(), OAuthAccessToken);
+
+        List<String> tokenInfo = new ArrayList<>();
+        tokenInfo.add("Bearer " + tokenProvider.generateToken(member.getUserId()).getAccessToken());
+        tokenInfo.add(member.getUserId());
+
+        return tokenInfo;
+    }
+
+    private Member saveOrUpdate(Map userResponse, String token) {
+        Optional<Member> optionalMember = memberRepository.findByUserId(userResponse.get("login").toString());
+        Optional<GithubInfo> optionalGithubInfo = githubInfoRepository.findByUserId(userResponse.get("login").toString());
+        Member member;
+        GithubInfo githubInfo;
+
+        String userId = userResponse.get("login").toString();
+        String userCode = userResponse.get("id").toString();
+        String nickname = userResponse.get("name").toString();
+        Level level =  levelRepository.findById(1L).get();
+
+        if(optionalMember.isEmpty()) {
+            Random random = new Random();
+            int randNum = random.nextInt(30) + 1;
+            String imageUrl = awsS3Api.getImageUrl("profiles/basic/" + randNum + ".png");
+
+            member = Member.register(userId, userCode, nickname, token, imageUrl, level);
+            githubInfo = GithubInfo.builder()
+                    .userId(userId)
+                    .username(nickname)
+                    .accessToken(token)
+                    .build();
+        }
+        else if(optionalGithubInfo.isEmpty()) {
+            member = optionalMember.get();
+            member.update(userCode, token);
+            githubInfo = GithubInfo.builder()
+                    .userId(userId)
+                    .username(nickname)
+                    .accessToken(token)
+                    .build();
+        }
+        else {
+            member = optionalMember.get();
+            member.update(userCode, token);
+            githubInfo = optionalGithubInfo.get();
+
+            githubInfo.setAccessToken(token);
+            githubInfo.setUsername(nickname);
+        }
+        memberRepository.save(member);
+
+        githubInfo.setMember(member);
+        githubInfoRepository.save(githubInfo);
+        return member;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- Callback URL을 Client 주소로 받아 authorization_code를 이용한 로직으로 변경 및 authorization_code를 이용해 OAuth 토큰 발급
- 발급된 OAuth 토큰으로 Github측에 정보를 요청해 해당 사용자의 정보 추출 및 그에 따른 회원 가입 로직 추가

## Merge 전 필요 작업 (Checklist before merge)

## 희망 리뷰 완료 일 (Expected due date)

